### PR TITLE
fix: remove unnecessary version constraints in debugging patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/enabledebugging/annotations/EnableDebuggingCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/enabledebugging/annotations/EnableDebuggingCompatibility.kt
@@ -5,19 +5,7 @@ import app.revanced.patcher.annotation.Package
 
 @Compatibility(
     [Package(
-        "com.google.android.youtube",
-        arrayOf(
-            "17.14.35",
-            "17.17.34",
-            "17.19.36",
-            "17.20.37",
-            "17.22.36",
-            "17.23.35",
-            "17.23.36",
-            "17.24.34",
-            "17.24.35",
-            "17.25.34"
-        )
+        "com.google.android.youtube", arrayOf()
     )]
 )
 @Target(AnnotationTarget.CLASS)


### PR DESCRIPTION
this patch is also compatible with every android app but there doesnt seem to be a good way to specify that