### PR TITLE
Specify latest working Twitter target in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The official Patch bundle provided by ReVanced and the community.
 
 | 💊 Patch | 📜 Description | 🏹 Target Version |
 |:--------:|:--------------:|:-----------------:|
-| `timeline-ads` | Removes ads from the Twitter timeline. | all |
+| `timeline-ads` | Removes ads from the Twitter timeline. | 9.50.0 |
 </details>
 
 ### 📦 `com.reddit.frontpage`


### PR DESCRIPTION
Related ReVanced/revanced-patches-template#2245

The twitter patch seems to have been broken for a while and having `target: all` in the readme is confusing.