### PR TITLE
fix(youtube/general-ads): Add back general ad resource patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/ad/general/bytecode/patch/GeneralBytecodeAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/general/bytecode/patch/GeneralBytecodeAdsPatch.kt
@@ -21,6 +21,7 @@ import app.revanced.patcher.util.smali.ExternalLabel
 import app.revanced.patches.youtube.ad.general.annotation.GeneralAdsCompatibility
 import app.revanced.patches.youtube.ad.general.bytecode.extensions.MethodExtensions.findMutableMethodOf
 import app.revanced.patches.youtube.ad.general.bytecode.extensions.MethodExtensions.toDescriptor
+import app.revanced.patches.youtube.ad.general.resource.patch.GeneralResourceAdsPatch
 import app.revanced.patches.youtube.misc.integrations.patch.IntegrationsPatch
 import app.revanced.patches.youtube.misc.mapping.patch.ResourceMappingResourcePatch
 import app.revanced.patches.youtube.misc.settings.bytecode.patch.SettingsPatch
@@ -38,7 +39,7 @@ import org.jf.dexlib2.iface.reference.MethodReference
 import org.jf.dexlib2.iface.reference.StringReference
 
 @Patch
-@DependsOn([ResourceMappingResourcePatch::class, IntegrationsPatch::class, SettingsPatch::class])
+@DependsOn([ResourceMappingResourcePatch::class, IntegrationsPatch::class, SettingsPatch::class, GeneralResourceAdsPatch::class])
 @Name("general-ads")
 @Description("Removes general ads.")
 @GeneralAdsCompatibility

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/general/resource/patch/GeneralResourceAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/general/resource/patch/GeneralResourceAdsPatch.kt
@@ -1,0 +1,60 @@
+package app.revanced.patches.youtube.ad.general.resource.patch
+
+import app.revanced.extensions.doRecursively
+import app.revanced.extensions.startsWithAny
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.impl.ResourceData
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Dependencies
+import app.revanced.patcher.patch.impl.ResourcePatch
+import app.revanced.patches.youtube.ad.general.annotation.GeneralAdsCompatibility
+import app.revanced.patches.youtube.misc.manifest.patch.FixLocaleConfigErrorPatch
+import org.w3c.dom.Element
+
+@Dependencies(dependencies = [FixLocaleConfigErrorPatch::class])
+@Name("general-resource-ads")
+@Description("Patch to remove general ads in resources.")
+@GeneralAdsCompatibility
+@Version("0.0.1")
+class GeneralResourceAdsPatch : ResourcePatch() {
+    // list of resource file names which need to be hidden
+    private val resourceFileNames = arrayOf(
+        "compact_promoted_video_item.xml",
+        "inline_muted_metadata_swap.xml",
+        "interstitial_promo_view.xml",
+        "pip_ad_overlay.xml",
+        "promoted_",
+        "watch_metadata_companion_cards.xml",
+        //"watch_while_activity.xml" // FIXME: find out why patching this resource fails
+    )
+
+    // the attributes to change the value of
+    private val replacements = arrayOf(
+        "height",
+        "width",
+        "marginTop",
+    )
+
+    override fun execute(data: ResourceData): PatchResult {
+        data.forEach {
+            if (!it.name.startsWithAny(*resourceFileNames)) return@forEach
+
+            // for each file in the "layouts" directory replace all necessary attributes content
+            data.xmlEditor[it.absolutePath].use { editor ->
+                editor.file.doRecursively { node ->
+                    replacements.forEach replacement@{ replacement ->
+                        if (node !is Element) return@replacement
+
+                        node.getAttributeNode("android:layout_$replacement")?.let { attribute ->
+                            attribute.textContent = "1.0dip"
+                        }
+                    }
+                }
+            }
+        }
+        return PatchResultSuccess()
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/general/resource/patch/GeneralResourceAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/general/resource/patch/GeneralResourceAdsPatch.kt
@@ -8,13 +8,13 @@ import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.data.impl.ResourceData
 import app.revanced.patcher.patch.PatchResult
 import app.revanced.patcher.patch.PatchResultSuccess
-import app.revanced.patcher.patch.annotations.Dependencies
+import app.revanced.patcher.patch.annotations.DependsOn
 import app.revanced.patcher.patch.impl.ResourcePatch
 import app.revanced.patches.youtube.ad.general.annotation.GeneralAdsCompatibility
 import app.revanced.patches.youtube.misc.manifest.patch.FixLocaleConfigErrorPatch
 import org.w3c.dom.Element
 
-@Dependencies(dependencies = [FixLocaleConfigErrorPatch::class])
+@DependsOn(dependencies = [FixLocaleConfigErrorPatch::class])
 @Name("general-resource-ads")
 @Description("Patch to remove general ads in resources.")
 @GeneralAdsCompatibility

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/general/resource/patch/GeneralResourceAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/general/resource/patch/GeneralResourceAdsPatch.kt
@@ -5,11 +5,11 @@ import app.revanced.extensions.startsWithAny
 import app.revanced.patcher.annotation.Description
 import app.revanced.patcher.annotation.Name
 import app.revanced.patcher.annotation.Version
-import app.revanced.patcher.data.impl.ResourceData
+import app.revanced.patcher.data.ResourceContext
 import app.revanced.patcher.patch.PatchResult
 import app.revanced.patcher.patch.PatchResultSuccess
 import app.revanced.patcher.patch.annotations.DependsOn
-import app.revanced.patcher.patch.impl.ResourcePatch
+import app.revanced.patcher.patch.ResourcePatch
 import app.revanced.patches.youtube.ad.general.annotation.GeneralAdsCompatibility
 import app.revanced.patches.youtube.misc.manifest.patch.FixLocaleConfigErrorPatch
 import org.w3c.dom.Element
@@ -19,7 +19,7 @@ import org.w3c.dom.Element
 @Description("Patch to remove general ads in resources.")
 @GeneralAdsCompatibility
 @Version("0.0.1")
-class GeneralResourceAdsPatch : ResourcePatch() {
+class GeneralResourceAdsPatch : ResourcePatch {
     // list of resource file names which need to be hidden
     private val resourceFileNames = arrayOf(
         "compact_promoted_video_item.xml",
@@ -38,12 +38,12 @@ class GeneralResourceAdsPatch : ResourcePatch() {
         "marginTop",
     )
 
-    override fun execute(data: ResourceData): PatchResult {
-        data.forEach {
+    override fun execute(context: ResourceContext): PatchResult {
+        context.forEach {
             if (!it.name.startsWithAny(*resourceFileNames)) return@forEach
 
             // for each file in the "layouts" directory replace all necessary attributes content
-            data.xmlEditor[it.absolutePath].use { editor ->
+            context.xmlEditor[it.absolutePath].use { editor ->
                 editor.file.doRecursively { node ->
                     replacements.forEach replacement@{ replacement ->
                         if (node !is Element) return@replacement

--- a/src/main/kotlin/app/revanced/patches/youtube/ad/general/resource/patch/GeneralResourceAdsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/ad/general/resource/patch/GeneralResourceAdsPatch.kt
@@ -22,13 +22,8 @@ import org.w3c.dom.Element
 class GeneralResourceAdsPatch : ResourcePatch {
     // list of resource file names which need to be hidden
     private val resourceFileNames = arrayOf(
-        "compact_promoted_video_item.xml",
-        "inline_muted_metadata_swap.xml",
-        "interstitial_promo_view.xml",
-        "pip_ad_overlay.xml",
-        "promoted_",
-        "watch_metadata_companion_cards.xml",
-        //"watch_while_activity.xml" // FIXME: find out why patching this resource fails
+        "compact_promoted_",
+        "promoted_video_",
     )
 
     // the attributes to change the value of


### PR DESCRIPTION
From comments of issue ReVanced/revanced-patches-template#1955 

> > the are not randomly or rarely like people say in the issue ReVanced/revanced-patches-template#2343, the ads are always there
> 
> It looks like this issue is only on tablet landscape mode, no matter what brand the table or phone is. My samsung table also has ads showing always on main and player ui unless reverting resource patch commit.
> 
> However devs are no more using resource patch method, so just wait patiently until they come across another solution. Personally, I use my own fork of patch that use resource patch for hiding cosmetic ads. Try this one: [`revanced-patches`](https://github.com/TheNoFace/revanced-patches)
