### PR TITLE
feat: short app name

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/misc/microg/shared/Constants.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/microg/shared/Constants.kt
@@ -1,7 +1,7 @@
 package app.revanced.patches.music.misc.microg.shared
 
 object Constants {
-    internal const val REVANCED_MUSIC_APP_NAME = "YouTube Music ReVanced"
+    internal const val REVANCED_MUSIC_APP_NAME = "YT Music ReVanced"
     internal const val REVANCED_MUSIC_PACKAGE_NAME = "app.revanced.android.apps.youtube.music"
     internal const val MUSIC_PACKAGE_NAME = "com.google.android.apps.youtube.music"
     internal const val SPOOFED_PACKAGE_NAME = MUSIC_PACKAGE_NAME


### PR DESCRIPTION
Current name is too long that it doesn't even fit on launcher. Another thing is, main YouTube music also use YT Music on Launcher