### PR TITLE
feat(youtube-music): bump compatibility to 5.36.51

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/ad/video/annotations/MusicVideoAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/ad/video/annotations/MusicVideoAdsCompatibility.kt
@@ -20,7 +20,8 @@ import app.revanced.patcher.annotation.Package
             "5.28.52",
             "5.29.52",
             "5.31.50",
-            "5.34.51"
+            "5.34.51",
+            "5.36.51"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/audio/codecs/annotations/CodecsUnlockCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/audio/codecs/annotations/CodecsUnlockCompatibility.kt
@@ -20,7 +20,8 @@ import app.revanced.patcher.annotation.Package
             "5.28.52",
             "5.29.52",
             "5.31.50",
-            "5.34.51"
+            "5.34.51",
+            "5.36.51"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/audio/exclusiveaudio/annotations/ExclusiveAudioCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/audio/exclusiveaudio/annotations/ExclusiveAudioCompatibility.kt
@@ -20,7 +20,8 @@ import app.revanced.patcher.annotation.Package
             "5.28.52",
             "5.29.52",
             "5.31.50",
-            "5.34.51"
+            "5.34.51",
+            "5.36.51"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/compactheader/annotations/CompactHeaderCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/compactheader/annotations/CompactHeaderCompatibility.kt
@@ -19,7 +19,8 @@ import app.revanced.patcher.annotation.Package
             "5.28.52",
             "5.29.52",
             "5.31.50",
-            "5.34.51"
+            "5.34.51",
+            "5.36.51"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
@@ -20,7 +20,8 @@ import app.revanced.patcher.annotation.Package
             "5.28.52",
             "5.29.52",
             "5.31.50",
-            "5.34.51"
+            "5.34.51",
+            "5.36.51"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/premium/annotations/HideGetPremiumCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/premium/annotations/HideGetPremiumCompatibility.kt
@@ -20,7 +20,8 @@ import app.revanced.patcher.annotation.Package
             "5.28.52",
             "5.29.52",
             "5.31.50",
-            "5.34.51"
+            "5.34.51",
+            "5.36.51"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/tastebuilder/annotations/RemoveTasteBuilderCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/tastebuilder/annotations/RemoveTasteBuilderCompatibility.kt
@@ -22,7 +22,8 @@ import app.revanced.patcher.annotation.Package
             "5.28.52",
             "5.29.52",
             "5.31.50",
-            "5.34.51"
+            "5.34.51",
+            "5.36.51"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/annotations/RemoveUpgradeButtonCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/annotations/RemoveUpgradeButtonCompatibility.kt
@@ -20,7 +20,8 @@ import app.revanced.patcher.annotation.Package
             "5.28.52",
             "5.29.52",
             "5.31.50",
-            "5.34.51"
+            "5.34.51",
+            "5.36.51"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/misc/microg/annotations/MusicMicroGPatchCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/microg/annotations/MusicMicroGPatchCompatibility.kt
@@ -20,7 +20,8 @@ import app.revanced.patcher.annotation.Package
             "5.28.52",
             "5.29.52",
             "5.31.50",
-            "5.34.51"
+            "5.34.51",
+            "5.36.51"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/premium/backgroundplay/annotations/BackgroundPlayCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/premium/backgroundplay/annotations/BackgroundPlayCompatibility.kt
@@ -20,7 +20,8 @@ import app.revanced.patcher.annotation.Package
             "5.28.52",
             "5.29.52",
             "5.31.50",
-            "5.34.51"
+            "5.34.51",
+            "5.36.51"
         )
     )]
 )


### PR DESCRIPTION
Bumps the compatibility of the YouTube Music patches to version `5.36.51`. All patches still work.