### PR TITLE
Decrease YT speed increments from 0.25 to 0.125

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/video/speed/custom/patch/CustomVideoSpeedPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/video/speed/custom/patch/CustomVideoSpeedPatch.kt
@@ -159,7 +159,7 @@ class CustomVideoSpeedPatch : BytecodePatch(
         val videoSpeedsGranularity by option(
             PatchOption.StringOption(
                 "granularity",
-                "16",
+                "32",
                 "Video speed granularity",
                 "The granularity of the video speeds. The higher the value, the more speeds will be available.",
                 true


### PR DESCRIPTION
1.25x and 1.5x speed are too fast or slow for some videos. I think power users would want 1.125 and 1.375.

Downside: doubles the options in the already lengthy custom playback speed selector. Maybe in the future we could make the custom playback range/increments customizable in settings? (Or replace the array of selections with +/- buttons.)