### PR TITLE
fix(youtube/fix-playback): stop playlist auto skips

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/fingerprints/VideoEndListenerFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/fingerprints/VideoEndListenerFingerprint.kt
@@ -1,0 +1,21 @@
+package app.revanced.patches.youtube.misc.fix.playback.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object VideoEndListenerFingerprint : MethodFingerprint(
+    returnType = "Z",
+    access = AccessFlags.PUBLIC or AccessFlags.FINAL,
+    opcodes = listOf(
+        Opcode.INVOKE_VIRTUAL_RANGE,
+        Opcode.IGET_OBJECT,
+        Opcode.IGET_OBJECT,
+        Opcode.CHECK_CAST,
+        Opcode.CONST_WIDE_32
+    ),
+    strings = listOf(
+        "Attempting to seek during an ad"
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/fingerprints/VideoEndListenerLabelFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/fingerprints/VideoEndListenerLabelFingerprint.kt
@@ -5,16 +5,15 @@ import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import org.jf.dexlib2.AccessFlags
 import org.jf.dexlib2.Opcode
 
-object VideoEndListenerFingerprint : MethodFingerprint(
+object VideoEndListenerLabelFingerprint : MethodFingerprint(
     returnType = "Z",
     access = AccessFlags.PUBLIC or AccessFlags.FINAL,
     opcodes = listOf(
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.INVOKE_VIRTUAL_RANGE,
-        Opcode.IGET_OBJECT,
-        Opcode.IGET_OBJECT,
-        Opcode.CHECK_CAST,
-        Opcode.CONST_WIDE_32
+        Opcode.INVOKE_STATIC,
+        Opcode.MOVE_RESULT_WIDE,
+        Opcode.CMP_LONG,
+        Opcode.IF_LEZ,
+        Opcode.GOTO
     ),
     strings = listOf(
         "Attempting to seek during an ad"

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/patch/FixPlaybackPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/fix/playback/patch/FixPlaybackPatch.kt
@@ -5,19 +5,25 @@ import app.revanced.patcher.annotation.Description
 import app.revanced.patcher.annotation.Name
 import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.addInstructions
 import app.revanced.patcher.extensions.removeInstruction
+import app.revanced.patcher.extensions.instruction
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint.Companion.resolve
 import app.revanced.patcher.patch.PatchResult
 import app.revanced.patcher.patch.PatchResultSuccess
 import app.revanced.patcher.patch.BytecodePatch
 import app.revanced.patcher.patch.annotations.DependsOn
+import app.revanced.patcher.util.smali.ExternalLabel
 import app.revanced.patches.shared.settings.preference.impl.StringResource
 import app.revanced.patches.shared.settings.preference.impl.SwitchPreference
 import app.revanced.patches.youtube.misc.fix.playback.annotations.FixPlaybackCompatibility
 import app.revanced.patches.youtube.misc.fix.playback.fingerprints.VideoEndListenerFingerprint
+import app.revanced.patches.youtube.misc.fix.playback.fingerprints.VideoEndListenerLabelFingerprint
 import app.revanced.patches.youtube.misc.integrations.patch.IntegrationsPatch
 import app.revanced.patches.youtube.misc.settings.bytecode.patch.SettingsPatch
 import app.revanced.patches.youtube.misc.video.information.patch.VideoInformationPatch
 import app.revanced.patches.youtube.misc.video.videoid.patch.VideoIdPatch
+import org.jf.dexlib2.iface.instruction.OneRegisterInstruction
 
 @DependsOn([
     IntegrationsPatch::class,
@@ -30,7 +36,7 @@ import app.revanced.patches.youtube.misc.video.videoid.patch.VideoIdPatch
 @FixPlaybackCompatibility
 @Version("0.0.1")
 class FixPlaybackPatch : BytecodePatch(
-    listOf(VideoEndListenerFingerprint)
+    listOf(VideoEndListenerFingerprint, VideoEndListenerLabelFingerprint)
 ) {
     override fun execute(context: BytecodeContext): PatchResult {
         SettingsPatch.PreferenceScreen.MISC.addPreferences(
@@ -49,19 +55,47 @@ class FixPlaybackPatch : BytecodePatch(
             )
         )
 
-        val result = VideoEndListenerFingerprint.result ?: return VideoEndListenerFingerprint.toErrorResult()
-        val method = result.mutableMethod
-        val index = result.scanResult.patternScanResult!!.startIndex
+        // TODO: Improve code to be more ideal
+        VideoEndListenerFingerprint.result?.let { result ->
+            val insertIndex = result.scanResult.patternScanResult!!.startIndex
+            val registerIndex = insertIndex - 1
+            val jumpIndex = insertIndex + 2
 
-        // Part that calls the Method that recognizes that the video is over
-        method.removeInstruction(index)
+            // TODO: Add 'fixPlaybackEnabled()Z' function to return value of SettingsEnum in integrations
+            with(result.mutableMethod) {
+                val instructions = implementation!!.instructions
+                val register = (instructions[registerIndex] as OneRegisterInstruction).registerA
+                addInstructions(
+                    insertIndex, """
+                        invoke-static {}, $INTEGRATIONS_CLASS_DESCRIPTOR->fixPlaybackEnabled()Z
+                        move-result v$register
+                        if-nez v$register, :stop_repeat
+                    """, listOf(ExternalLabel("stop_repeat", instruction(jumpIndex)))
+                )
+            }
 
-        // If you don't remove this method call, video will stop as soon as it starts
-        method.removeInstruction(index - 1)
+            VideoEndListenerLabelFingerprint.also { it.resolve(context, result.classDef) }.result?.let { labelResult ->
+                val labelInsertIndex = labelResult.scanResult.patternScanResult!!.endIndex
+
+                with(labelResult.mutableMethod) {
+                    removeInstruction(labelInsertIndex)
+                    addInstructions(
+                        labelInsertIndex, """
+                            goto :goto_new
+                        """, listOf(ExternalLabel("goto_new", instruction(registerIndex)))
+                    )
+                }
+            } ?: return VideoEndListenerLabelFingerprint.toErrorResult()
+        } ?: return VideoEndListenerFingerprint.toErrorResult()
 
         // If a new video loads, fix the playback issue
-        VideoIdPatch.injectCall("Lapp/revanced/integrations/patches/FixPlaybackPatch;->newVideoLoaded(Ljava/lang/String;)V")
+        VideoIdPatch.injectCall("$INTEGRATIONS_CLASS_DESCRIPTOR->newVideoLoaded(Ljava/lang/String;)V")
 
         return PatchResultSuccess()
+    }
+
+    private companion object {
+        const val INTEGRATIONS_CLASS_DESCRIPTOR =
+            "Lapp/revanced/integrations/patches/FixPlaybackPatch;"
     }
 }


### PR DESCRIPTION
Current `fix-playback` patch does not work properly with playlists https://github.com/revanced/revanced-patches/issues/1206

To be precise, the patch itself works fine, but there is an issue with playlists being skipped automatically

This PR fixes an issue where playlists are automatically skipped by the `fix-playback` patch

Unfortunately, since the playback issue is not reproduced on my device, I have not been able to test whether this PR works normally while fixing the issue that occurs in the UK region.

So I'll mark the PR as draft.

What I checked
- Playlists are no longer automatically skipped when `Fix video playback issues` is set to ON

Parts that require confirmation
- When `Fix video playback issues` is set to ON, the existing action works as intended, but the playlists auto skip issue is resolved.
(need an account that can reproduce the playback issue)

If this patch is not confirmed to be working properly by the maintainers, please leave a comment and close the PR.