### PR TITLE
feat(youtube): `double-back-to-close` patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/annotations/DoubleBackToCloseCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/annotations/DoubleBackToCloseCompatibility.kt
@@ -1,0 +1,13 @@
+package app.revanced.patches.youtube.misc.doublebacktoclose.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility(
+    [Package(
+        "com.google.android.youtube", arrayOf("17.49.37")
+    )]
+)
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class DoubleBackToCloseCompatibility

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/fingerprint/OnBackPressedFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/fingerprint/OnBackPressedFingerprint.kt
@@ -1,0 +1,14 @@
+package app.revanced.patches.youtube.misc.doublebacktoclose.fingerprint
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.Opcode
+
+object OnBackPressedFingerprint : MethodFingerprint(
+    opcodes = listOf(
+        Opcode.RETURN_VOID
+    ),
+    customFingerprint = { methodDef ->
+        methodDef.definingClass.endsWith("WatchWhileActivity;")
+                && methodDef.name == "onBackPressed"
+    }
+)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/fingerprint/ScrollPositionFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/fingerprint/ScrollPositionFingerprint.kt
@@ -1,0 +1,19 @@
+package app.revanced.patches.youtube.misc.doublebacktoclose.fingerprint
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object ScrollPositionFingerprint : MethodFingerprint(
+    returnType = "V",
+    access = AccessFlags.PROTECTED or AccessFlags.FINAL,
+    parameters = listOf("L"),
+    opcodes = listOf(
+        Opcode.IF_NEZ,
+        Opcode.INVOKE_DIRECT,
+        Opcode.RETURN_VOID
+    ),
+    strings = listOf("scroll_position")
+)
+

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/fingerprint/ScrollTopFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/fingerprint/ScrollTopFingerprint.kt
@@ -1,0 +1,21 @@
+package app.revanced.patches.youtube.misc.doublebacktoclose.fingerprint
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object ScrollTopFingerprint : MethodFingerprint(
+    returnType = "V",
+    access = AccessFlags.PUBLIC or AccessFlags.FINAL,
+    parameters = listOf(),
+    opcodes = listOf(
+        Opcode.CHECK_CAST,
+        Opcode.CONST_4,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.GOTO,
+        Opcode.IGET_OBJECT,
+        Opcode.INVOKE_INTERFACE
+    )
+)
+

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/fingerprint/ScrollTopParentFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/fingerprint/ScrollTopParentFingerprint.kt
@@ -1,0 +1,26 @@
+package app.revanced.patches.youtube.misc.doublebacktoclose.fingerprint
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object ScrollTopParentFingerprint : MethodFingerprint(
+    returnType = "V",
+    access = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
+    parameters = listOf("L", "L", "L", "L"),
+    opcodes = listOf(
+        Opcode.INVOKE_DIRECT,
+        Opcode.IPUT_OBJECT,
+        Opcode.IPUT_OBJECT,
+        Opcode.IPUT_OBJECT,
+        Opcode.IPUT_OBJECT,
+        Opcode.CONST_16,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.NEW_INSTANCE
+    ),
+    customFingerprint = { methodDef ->
+        methodDef.name == "<init>"
+    }
+)
+

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/patch/DoubleBackToClosePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/doublebacktoclose/patch/DoubleBackToClosePatch.kt
@@ -1,0 +1,113 @@
+package app.revanced.patches.youtube.misc.doublebacktoclose.patch
+
+import app.revanced.extensions.toErrorResult
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.data.toMethodWalker
+import app.revanced.patcher.extensions.addInstruction
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint.Companion.resolve
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.DependsOn
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patcher.util.proxy.mutableTypes.MutableMethod
+import app.revanced.patches.shared.settings.preference.impl.StringResource
+import app.revanced.patches.shared.settings.preference.impl.SwitchPreference
+import app.revanced.patches.youtube.misc.doublebacktoclose.annotations.DoubleBackToCloseCompatibility
+import app.revanced.patches.youtube.misc.doublebacktoclose.fingerprint.OnBackPressedFingerprint
+import app.revanced.patches.youtube.misc.doublebacktoclose.fingerprint.ScrollPositionFingerprint
+import app.revanced.patches.youtube.misc.doublebacktoclose.fingerprint.ScrollTopFingerprint
+import app.revanced.patches.youtube.misc.doublebacktoclose.fingerprint.ScrollTopParentFingerprint
+import app.revanced.patches.youtube.misc.integrations.patch.IntegrationsPatch
+import app.revanced.patches.youtube.misc.settings.bytecode.patch.SettingsPatch
+
+@Patch
+@DependsOn([IntegrationsPatch::class, SettingsPatch::class])
+@Name("double-back-to-close")
+@Description("Close the app by double-tapping the back button from the home feed.")
+@DoubleBackToCloseCompatibility
+@Version("0.0.1")
+class DoubleBackToClosePatch : BytecodePatch(
+    listOf(
+        OnBackPressedFingerprint,
+        ScrollPositionFingerprint,
+        ScrollTopParentFingerprint
+    )
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        SettingsPatch.PreferenceScreen.MISC.addPreferences(
+            SwitchPreference(
+                "revanced_enable_double_back_to_close",
+                StringResource("revanced_enable_double_back_to_close_title", "Enable double back to close"),
+                true,
+                StringResource("revanced_enable_double_back_to_close_summary_on", "Double back to close is enabled"),
+                StringResource("revanced_enable_double_back_to_close_summary_off", "Double back to close is disabled")
+            )
+        )
+
+
+        /*
+        Hook onBackPressed method inside WatchWhileActivity
+         */
+        OnBackPressedFingerprint.result?.let { result ->
+            val insertIndex = result.scanResult.patternScanResult!!.endIndex
+
+            with(result.mutableMethod) {
+                addInstruction(
+                    insertIndex,
+                    "invoke-static {p0}, $INTEGRATIONS_CLASS_DESCRIPTOR" +
+                    "->" +
+                    "closeActivityOnBackPressed(Lcom/google/android/apps/youtube/app/watchwhile/WatchWhileActivity;)V"
+                )
+            }
+        } ?: return OnBackPressedFingerprint.toErrorResult()
+
+
+        /*
+        Inject the methods which start of ScrollView
+         */
+        ScrollPositionFingerprint.result?.let { result ->
+            val insertMethod = context.toMethodWalker(result.method)
+                .nextMethod(result.scanResult.patternScanResult!!.startIndex + 1, true)
+                .getMethod() as MutableMethod
+
+            val insertIndex = insertMethod.implementation!!.instructions.size - 1 - 1
+
+            injectScrollView(insertMethod, insertIndex, "onStartScrollView")
+        } ?: return ScrollPositionFingerprint.toErrorResult()
+
+
+        /*
+        Inject the methods which stop of ScrollView
+         */
+        ScrollTopParentFingerprint.result?.let { parentResult ->
+            ScrollTopFingerprint.also { it.resolve(context, parentResult.classDef) }.result?.let { result ->
+                val insertMethod = result.mutableMethod
+                val insertIndex = result.scanResult.patternScanResult!!.endIndex
+
+                injectScrollView(insertMethod, insertIndex, "onStopScrollView")
+            } ?: return ScrollTopFingerprint.toErrorResult()
+        } ?: return ScrollTopParentFingerprint.toErrorResult()
+
+        return PatchResultSuccess()
+    }
+
+    private companion object {
+        const val INTEGRATIONS_CLASS_DESCRIPTOR =
+            "Lapp/revanced/integrations/patches/DouBleBackToClosePatch;"
+
+        fun injectScrollView(
+            method: MutableMethod,
+            index: Int,
+            descriptor: String
+        ) {
+            method.addInstruction(
+                index,
+                "invoke-static {}, $INTEGRATIONS_CLASS_DESCRIPTOR->$descriptor()V"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Make it possible to close the app by double-pressing the back button in the home feed

Also, it solves this issue https://github.com/revanced/revanced-patches/issues/615

depends on:
https://github.com/revanced/revanced-integrations/pull/251