### PR TITLE
feat(twitter): hide view count

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/annotations/HideViewsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/annotations/HideViewsCompatibility.kt
@@ -1,0 +1,9 @@
+package app.revanced.patches.twitter.layout.hideviews.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility([Package("com.twitter.android")])
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class HideViewsCompatibility

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/InlineActionTypesFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/InlineActionTypesFingerprint.kt
@@ -1,0 +1,15 @@
+package app.revanced.patches.twitter.layout.hideviews.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+
+object InlineActionTypesFingerprint : MethodFingerprint(
+    returnType = "Ljava/util/List",
+    access = AccessFlags.PUBLIC or AccessFlags.STATIC,
+    strings = listOf(
+        "getCurrentMemoizing()",
+        "android_animated_reply_icon_enabled",
+        "reply_voting_android_position_before_favorite_enabled"
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsContainerConstructorFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsContainerConstructorFingerprint.kt
@@ -7,7 +7,7 @@ import org.jf.dexlib2.Opcode
 
 object TweetStatsContainerConstructorFingerprint : MethodFingerprint(
     access = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
-    parameters = listOf("Landroid/view/View;"),
+    parameters = listOf("L"),
     opcodes = listOf(
         Opcode.INVOKE_DIRECT,
         Opcode.IPUT_OBJECT,

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsContainerConstructorFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsContainerConstructorFingerprint.kt
@@ -1,0 +1,22 @@
+package app.revanced.patches.twitter.layout.hideviews.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object TweetStatsContainerConstructorFingerprint : MethodFingerprint(
+    access = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
+    parameters = listOf("Landroid/view/View;"),
+    opcodes = listOf(
+        Opcode.INVOKE_DIRECT,
+        Opcode.IPUT_OBJECT,
+        Opcode.CONST,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.CHECK_CAST,
+        Opcode.CONST_4,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.INVOKE_VIRTUAL
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsContainerWrapperConstructorFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsContainerWrapperConstructorFingerprint.kt
@@ -1,0 +1,22 @@
+package app.revanced.patches.twitter.layout.hideviews.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object TweetStatsContainerWrapperConstructorFingerprint : MethodFingerprint(
+    access = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
+    parameters = listOf("Landroid/widget/RelativeLayout;"),
+    opcodes = listOf(
+        Opcode.INVOKE_DIRECT,
+        Opcode.IPUT_OBJECT,
+        Opcode.NEW_INSTANCE,
+        Opcode.INVOKE_DIRECT,
+        Opcode.IPUT_OBJECT,
+        Opcode.IGET_OBJECT,
+        Opcode.INVOKE_STATIC,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.IPUT_OBJECT
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsContainerWrapperConstructorFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsContainerWrapperConstructorFingerprint.kt
@@ -7,7 +7,7 @@ import org.jf.dexlib2.Opcode
 
 object TweetStatsContainerWrapperConstructorFingerprint : MethodFingerprint(
     access = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
-    parameters = listOf("Landroid/widget/RelativeLayout;"),
+    parameters = listOf("L"),
     opcodes = listOf(
         Opcode.INVOKE_DIRECT,
         Opcode.IPUT_OBJECT,

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsViewDelegateBinderFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsViewDelegateBinderFingerprint.kt
@@ -1,0 +1,26 @@
+package app.revanced.patches.twitter.layout.hideviews.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object TweetStatsViewDelegateBinderFingerprint : MethodFingerprint(
+    access = AccessFlags.PUBLIC or AccessFlags.FINAL,
+    opcodes = listOf(
+        Opcode.NEW_INSTANCE,
+        Opcode.CONST_16,
+        Opcode.INVOKE_DIRECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.IGET_OBJECT,
+        Opcode.NEW_INSTANCE,
+        Opcode.CONST_16,
+        Opcode.INVOKE_DIRECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.RETURN_OBJECT
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsBytecodePatch.kt
@@ -1,0 +1,89 @@
+package app.revanced.patches.twitter.layout.hideviews.patch
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.removeInstruction
+import app.revanced.patcher.extensions.removeInstructions
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint.Companion.resolve
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patches.twitter.layout.hideviews.fingerprints.InlineActionTypesFingerprint
+import app.revanced.patches.twitter.layout.hideviews.fingerprints.TweetStatsContainerConstructorFingerprint
+import app.revanced.patches.twitter.layout.hideviews.fingerprints.TweetStatsContainerWrapperConstructorFingerprint
+import app.revanced.patches.twitter.layout.hideviews.fingerprints.TweetStatsViewDelegateBinderFingerprint
+import org.jf.dexlib2.Opcode
+
+class HideViewsBytecodePatch : BytecodePatch(
+    listOf(
+        InlineActionTypesFingerprint,
+        TweetStatsContainerWrapperConstructorFingerprint,
+        TweetStatsContainerConstructorFingerprint,
+        TweetStatsViewDelegateBinderFingerprint
+    )
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        removeViewsFromTimeline(context)
+        removeTweetStatViewInitializer(context)
+        removeTweetStatViewWrapperInitializer(context)
+        removeViewDelegateBinderSubscription(context)
+        return PatchResultSuccess()
+    }
+
+    private fun removeViewsFromTimeline(context: BytecodeContext): PatchResult {
+        val result = InlineActionTypesFingerprint.result!!
+        val method = result.mutableMethod
+        val addViewsToActionBarMethodFingerprint = object : MethodFingerprint(
+            opcodes = listOf(
+                Opcode.INVOKE_STATIC,
+                Opcode.MOVE_RESULT,
+                Opcode.IF_EQZ,
+                Opcode.SGET_OBJECT,
+                Opcode.INVOKE_VIRTUAL,
+                Opcode.IF_EQZ,
+            )
+        ) {}
+        val addViewsToActionBarMethodLine = addViewsToActionBarMethodFingerprint.also {
+            it.resolve(context, method, result.classDef)
+        }.result!!.scanResult.patternScanResult!!.endIndex - 1
+        method.removeInstruction(addViewsToActionBarMethodLine)
+        return PatchResultSuccess()
+    }
+
+    private fun removeTweetStatViewInitializer(context: BytecodeContext) {
+        val result = TweetStatsContainerConstructorFingerprint.result!!
+        val method = result.mutableMethod
+        val returnFingerprint = object : MethodFingerprint(
+            opcodes = listOf(Opcode.RETURN_VOID)
+        ) {}
+        val addViewsToActionBarMethodLine = returnFingerprint.also {
+            it.resolve(context, method, result.classDef)
+        }.result!!.scanResult.patternScanResult!!.endIndex - 3
+        method.removeInstructions(addViewsToActionBarMethodLine, 2)
+    }
+
+    private fun removeTweetStatViewWrapperInitializer(context: BytecodeContext) {
+        val wrapperResult = TweetStatsContainerWrapperConstructorFingerprint.result!!
+        val wrapperMethod = wrapperResult.mutableMethod
+        val wrapperReturnFingerprint = object : MethodFingerprint(
+            opcodes = listOf(
+                Opcode.IGET_OBJECT,
+                Opcode.INVOKE_STATIC,
+                Opcode.MOVE_RESULT_OBJECT,
+                Opcode.IPUT_OBJECT,
+                Opcode.RETURN_VOID,
+            )
+        ) {}
+        val setupVariableLine = wrapperReturnFingerprint.also {
+            it.resolve(context, wrapperMethod, wrapperResult.classDef)
+        }.result!!.scanResult.patternScanResult!!.startIndex - 4
+        wrapperMethod.removeInstructions(setupVariableLine, 3)
+    }
+
+    private fun removeViewDelegateBinderSubscription(context: BytecodeContext) {
+        val binderResult = TweetStatsViewDelegateBinderFingerprint.result!!
+        val binderMethod = binderResult.mutableMethod
+        val bindLine = binderResult.scanResult.patternScanResult!!.startIndex - 4
+        binderMethod.removeInstructions(bindLine, 9)
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
@@ -13,7 +13,7 @@ import org.w3c.dom.Element
 @Patch
 @DependsOn([HideViewsBytecodePatch::class])
 @Name("hide-views")
-@Description("Hides the view count under tweets.")
+@Description("Hides the view stats under tweets.")
 @HideViewsCompatibility
 @Version("0.0.1")
 class HideViewsResourcePatch : ResourcePatch {

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
@@ -12,7 +12,7 @@ import org.w3c.dom.Element
 
 @Patch
 @DependsOn([HideViewsBytecodePatch::class])
-@Name("hide-views")
+@Name("hide-views-stats")
 @Description("Hides the view stats under tweets.")
 @HideViewsCompatibility
 @Version("0.0.1")

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
@@ -1,0 +1,34 @@
+package app.revanced.patches.twitter.layout.hideviews.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.ResourceContext
+import app.revanced.patcher.patch.*
+import app.revanced.patcher.patch.annotations.DependsOn
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.twitter.layout.hideviews.annotations.HideViewsCompatibility
+import org.w3c.dom.Element
+
+@Patch
+@DependsOn([HideViewsBytecodePatch::class])
+@Name("hide-views")
+@Description("Hides the view count under tweets.")
+@HideViewsCompatibility
+@Version("0.0.1")
+class HideViewsResourcePatch : ResourcePatch {
+    override fun execute(context: ResourceContext): PatchResult {
+        arrayOf(
+            "res/layout/condensed_tweet_stats.xml",
+            "res/layout/focal_tweet_stats.xml"
+        ).forEach { file ->
+            context.xmlEditor[file].use { editor ->
+                val tags = editor.file.getElementsByTagName("com.twitter.ui.tweet.TweetStatView")
+                List(tags.length) { tags.item(it) as Element }
+                    .filter { it.getAttribute("android:id").contains("views_stat") }
+                    .forEach { it.parentNode.removeChild(it) }
+            }
+        }
+        return PatchResultSuccess()
+    }
+}


### PR DESCRIPTION
This new patch partly fixes ReVanced/revanced-patches-template#1534 by removing the views stat on the timeline.
I had planned to remove the views stat when opening a tweet as well, but I couldn't get it to work without crashing (seemed like I couldn't just remove the element in the view like I did here because it was referenced somewhere in the code, resulting in an Exception).
I tested the patch on app version 9.69.1 and it works fine.
Also this is my first contribution here so I'm open to any suggestions.