### PR TITLE
fix for ReturnYouTubeDislikes not always shown

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/patch/ReturnYouTubeDislikePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/patch/ReturnYouTubeDislikePatch.kt
@@ -59,7 +59,7 @@ class ReturnYouTubeDislikePatch : BytecodePatch(
 
             val conversionContextParam = 5
             val textRefParam = createComponentMethod.parameters.size - 2
-            val insertIndex = scanResult.stringsScanResult!!.matches.first().index - 2
+            val insertIndex = 0;
 
             createComponentMethod.addInstructions(
                 insertIndex,

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/patch/ReturnYouTubeDislikePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/returnyoutubedislike/patch/ReturnYouTubeDislikePatch.kt
@@ -59,7 +59,9 @@ class ReturnYouTubeDislikePatch : BytecodePatch(
 
             val conversionContextParam = 5
             val textRefParam = createComponentMethod.parameters.size - 2
-            val insertIndex = 0;
+            // insert index must be 0, otherwise UI does not updated correctly in some situations
+            // such as switching from full screen or when using previous/next overlay buttons.
+            val insertIndex = 0
 
             createComponentMethod.addInstructions(
                 insertIndex,


### PR DESCRIPTION
Fix for issue https://github.com/revanced/revanced-patches/issues/1133

This fixes the issue of dislikes not shown when switching out of full screen, and when using the next/previous video overlay buttons.