### PR TITLE
fix(youtube/hide-info-cards) Fix for info cards always hiding, even if setting is turned off

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/hideinfocards/patch/HideInfocardsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/hideinfocards/patch/HideInfocardsPatch.kt
@@ -45,7 +45,7 @@ class HideInfocardsPatch : BytecodePatch(
                                 "Landroid/view/View;->setVisibility(I)V")
             }
 
-            replaceInstruction(
+            addInstructions(
                 invokeInstructionIndex,
                 "invoke-static {v${(instruction(invokeInstructionIndex) as? BuilderInstruction35c)?.registerC}}," +
                         " Lapp/revanced/integrations/patches/HideInfocardsPatch;->hideInfocardsIncognito(Landroid/view/View;)V"


### PR DESCRIPTION
Fix for issue https://github.com/revanced/revanced-patches/issues/1187

Changed the patch so it does not replace the existing method call, as it appears the original method makes the card visible to begin with.

Verified this fix using both normal and incognito mode.