### PR TITLE
feat(music): update patches compatibility to v5.39.52

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/ad/video/annotations/MusicVideoAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/ad/video/annotations/MusicVideoAdsCompatibility.kt
@@ -22,7 +22,8 @@ import app.revanced.patcher.annotation.Package
             "5.31.50",
             "5.34.51",
             "5.36.51",
-            "5.38.53"
+            "5.38.53",
+            "5.39.52"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/audio/codecs/annotations/CodecsUnlockCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/audio/codecs/annotations/CodecsUnlockCompatibility.kt
@@ -22,7 +22,8 @@ import app.revanced.patcher.annotation.Package
             "5.31.50",
             "5.34.51",
             "5.36.51",
-            "5.38.53"
+            "5.38.53",
+            "5.39.52"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/audio/exclusiveaudio/annotations/ExclusiveAudioCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/audio/exclusiveaudio/annotations/ExclusiveAudioCompatibility.kt
@@ -22,7 +22,8 @@ import app.revanced.patcher.annotation.Package
             "5.31.50",
             "5.34.51",
             "5.36.51",
-            "5.38.53"
+            "5.38.53",
+            "5.39.52"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/compactheader/annotations/CompactHeaderCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/compactheader/annotations/CompactHeaderCompatibility.kt
@@ -21,7 +21,8 @@ import app.revanced.patcher.annotation.Package
             "5.31.50",
             "5.34.51",
             "5.36.51",
-            "5.38.53"
+            "5.38.53",
+            "5.39.52"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/minimizedplayback/annotations/MinimizedPlaybackCompatibility.kt
@@ -22,7 +22,8 @@ import app.revanced.patcher.annotation.Package
             "5.31.50",
             "5.34.51",
             "5.36.51",
-            "5.38.53"
+            "5.38.53",
+            "5.39.52"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/premium/annotations/HideGetPremiumCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/premium/annotations/HideGetPremiumCompatibility.kt
@@ -22,7 +22,8 @@ import app.revanced.patcher.annotation.Package
             "5.31.50",
             "5.34.51",
             "5.36.51",
-            "5.38.53"
+            "5.38.53",
+            "5.39.52"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/tastebuilder/annotations/RemoveTasteBuilderCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/tastebuilder/annotations/RemoveTasteBuilderCompatibility.kt
@@ -24,7 +24,8 @@ import app.revanced.patcher.annotation.Package
             "5.31.50",
             "5.34.51",
             "5.36.51",
-            "5.38.53"
+            "5.38.53",
+            "5.39.52"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/annotations/RemoveUpgradeButtonCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/layout/upgradebutton/annotations/RemoveUpgradeButtonCompatibility.kt
@@ -22,7 +22,8 @@ import app.revanced.patcher.annotation.Package
             "5.31.50",
             "5.34.51",
             "5.36.51",
-            "5.38.53"
+            "5.38.53",
+            "5.39.52"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/misc/microg/annotations/MusicMicroGPatchCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/misc/microg/annotations/MusicMicroGPatchCompatibility.kt
@@ -22,7 +22,8 @@ import app.revanced.patcher.annotation.Package
             "5.31.50",
             "5.34.51",
             "5.36.51",
-            "5.38.53"
+            "5.38.53",
+            "5.39.52"
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/music/premium/backgroundplay/annotations/BackgroundPlayCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/music/premium/backgroundplay/annotations/BackgroundPlayCompatibility.kt
@@ -22,7 +22,8 @@ import app.revanced.patcher.annotation.Package
             "5.31.50",
             "5.34.51",
             "5.36.51",
-            "5.38.53"
+            "5.38.53",
+            "5.39.52"
         )
     )]
 )


### PR DESCRIPTION
Updates the music patches to support `5.39.52`. All patches still work.