### PR TITLE
fix(twitter/hide-views-stats): fingerprint not working with certain app versions

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsViewDelegateBinderFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/fingerprints/TweetStatsViewDelegateBinderFingerprint.kt
@@ -8,19 +8,11 @@ import org.jf.dexlib2.Opcode
 object TweetStatsViewDelegateBinderFingerprint : MethodFingerprint(
     access = AccessFlags.PUBLIC or AccessFlags.FINAL,
     opcodes = listOf(
-        Opcode.NEW_INSTANCE,
-        Opcode.CONST_16,
-        Opcode.INVOKE_DIRECT,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.IGET_OBJECT,
-        Opcode.NEW_INSTANCE,
-        Opcode.CONST_16,
         Opcode.INVOKE_DIRECT,
         Opcode.INVOKE_VIRTUAL,
         Opcode.MOVE_RESULT_OBJECT,
         Opcode.INVOKE_VIRTUAL,
         Opcode.RETURN_OBJECT
-    )
+    ),
+    customFingerprint = { it.definingClass.endsWith("/FocalTweetStatsViewDelegateBinder;") }
 )

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsBytecodePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsBytecodePatch.kt
@@ -1,6 +1,7 @@
 package app.revanced.patches.twitter.layout.hideviews.patch
 
 import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.instruction
 import app.revanced.patcher.extensions.removeInstruction
 import app.revanced.patcher.extensions.removeInstructions
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
@@ -86,7 +87,15 @@ class HideViewsBytecodePatch : BytecodePatch(
 
     private fun removeViewDelegateBinderSubscription() {
         transformMethod(TweetStatsViewDelegateBinderFingerprint) { result, method ->
-            method.removeInstructions(result.scanResult.patternScanResult!!.startIndex - 4, 9)
+            var idx = result.scanResult.patternScanResult!!.startIndex
+            var end = -1
+            var n = 0
+            while (n < 2) {
+                if (method.instruction(idx--).opcode == Opcode.IGET_OBJECT && n++ == 0) {
+                    end = idx
+                }
+            }
+            method.removeInstructions(++idx, end - idx)
         }
     }
 

--- a/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/layout/hideviews/patch/HideViewsResourcePatch.kt
@@ -15,7 +15,7 @@ import org.w3c.dom.Element
 @Name("hide-views-stats")
 @Description("Hides the view stats under tweets.")
 @HideViewsCompatibility
-@Version("0.0.1")
+@Version("0.0.2")
 class HideViewsResourcePatch : ResourcePatch {
     override fun execute(context: ResourceContext): PatchResult {
         arrayOf(


### PR DESCRIPTION
Fixes ReVanced/revanced-patches-template#1470.

- Improved `TweetStatsViewDelegateBinderFingerprint` (smaller fingerprint, can directly match with the class name because it doesn't change between versions)
- Also improved the way the instructions are removed using this fingerprint (dynamically count how many instructions need to be removed)