### PR TITLE
feat(spotify-lite): enable on-demand patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/annotations/OnDemandCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/annotations/OnDemandCompatibility.kt
@@ -1,0 +1,11 @@
+package app.revanced.patches.spotify.lite.ondemand.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility(
+    [Package("com.spotify.lite")]
+)
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class OnDemandCompatibility

--- a/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/fingerprints/OnDemandFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/fingerprints/OnDemandFingerprint.kt
@@ -1,8 +1,10 @@
 package app.revanced.patches.spotify.lite.ondemand.fingerprints
 
+import app.revanced.patcher.fingerprint.method.annotation.FuzzyPatternScanMethod
 import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import org.jf.dexlib2.Opcode
 
+@FuzzyPatternScanMethod(2)
 object OnDemandFingerprint : MethodFingerprint(
     "L",
     parameters = listOf(),

--- a/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/fingerprints/OnDemandFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/fingerprints/OnDemandFingerprint.kt
@@ -1,0 +1,23 @@
+package app.revanced.patches.spotify.lite.ondemand.fingerprints
+
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.Opcode
+
+object OnDemandFingerprint : MethodFingerprint(
+    "L",
+    parameters = listOf(),
+    opcodes = listOf(
+        Opcode.INVOKE_STATIC,
+        Opcode.MOVE_RESULT,
+        Opcode.INVOKE_STATIC,
+        Opcode.MOVE_RESULT_OBJECT,
+        Opcode.IF_EQZ,
+        Opcode.SGET_OBJECT,
+        Opcode.GOTO,
+        Opcode.SGET_OBJECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT,
+        Opcode.IPUT,
+        Opcode.RETURN_OBJECT
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/patch/OnDemandPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/patch/OnDemandPatch.kt
@@ -1,5 +1,6 @@
 package app.revanced.patches.spotify.lite.ondemand.patch
 
+import app.revanced.extensions.toErrorResult
 import app.revanced.patcher.annotation.Description
 import app.revanced.patcher.annotation.Name
 import app.revanced.patcher.annotation.Version
@@ -13,8 +14,8 @@ import app.revanced.patches.spotify.lite.ondemand.annotations.OnDemandCompatibil
 import app.revanced.patches.spotify.lite.ondemand.fingerprints.OnDemandFingerprint
 
 @Patch
-@Name("enable-ondemand")
-@Description("Enables listening to songs on-demand, allowing to play any song from playlists, albums or artists without limitations.")
+@Name("enable-on-demand")
+@Description("Enables listening to songs on-demand, allowing to play any song from playlists, albums or artists without limitations. Does not disable ads.")
 @OnDemandCompatibility
 @Version("0.0.1")
 class OnDemandPatch : BytecodePatch(
@@ -27,7 +28,7 @@ class OnDemandPatch : BytecodePatch(
             val insertIndex = scanResult.patternScanResult!!.endIndex - 1
             // Force the UI to behave like with a Premium account
             mutableMethod.addInstruction(insertIndex,"const/4 v0, 0x2")
-        }
+        } ?: return OnDemandFingerprint.toErrorResult()
         return PatchResultSuccess()
     }
 }

--- a/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/patch/OnDemandPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/patch/OnDemandPatch.kt
@@ -14,7 +14,7 @@ import app.revanced.patches.spotify.lite.ondemand.fingerprints.OnDemandFingerpri
 
 @Patch
 @Name("enable-ondemand")
-@Description("Enables On-Demand to play any song from any artist.")
+@Description("Enables listening to songs on-demand, allowing to play any song from playlists, albums or artists without limitations.")
 @OnDemandCompatibility
 @Version("0.0.1")
 class OnDemandPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/patch/OnDemandPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/patch/OnDemandPatch.kt
@@ -15,7 +15,7 @@ import app.revanced.patches.spotify.lite.ondemand.fingerprints.OnDemandFingerpri
 
 @Patch
 @Name("enable-on-demand")
-@Description("Enables listening to songs on-demand, allowing to play any song from playlists, albums or artists without limitations. Does not disable ads.")
+@Description("Enables listening to songs on-demand, allowing to play any song from playlists, albums or artists without limitations. This does not remove ads.")
 @OnDemandCompatibility
 @Version("0.0.1")
 class OnDemandPatch : BytecodePatch(

--- a/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/patch/OnDemandPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/patch/OnDemandPatch.kt
@@ -1,0 +1,33 @@
+package app.revanced.patches.spotify.lite.ondemand.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.addInstruction
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.spotify.lite.ondemand.annotations.OnDemandCompatibility
+import app.revanced.patches.spotify.lite.ondemand.fingerprints.OnDemandFingerprint
+
+@Patch
+@Name("enable-ondemand")
+@Description("Enables On-Demand to play any song from any artist.")
+@OnDemandCompatibility
+@Version("0.0.1")
+class OnDemandPatch : BytecodePatch(
+    listOf(
+        OnDemandFingerprint
+    )
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        OnDemandFingerprint.result?.apply {
+            val insertIndex = scanResult.patternScanResult!!.endIndex - 1
+            // Force the UI to behave like with a Premium account
+            mutableMethod.addInstruction(insertIndex,"const/4 v0, 0x2")
+        }
+        return PatchResultSuccess()
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/patch/OnDemandPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/spotify/lite/ondemand/patch/OnDemandPatch.kt
@@ -26,8 +26,8 @@ class OnDemandPatch : BytecodePatch(
     override fun execute(context: BytecodeContext): PatchResult {
         OnDemandFingerprint.result?.apply {
             val insertIndex = scanResult.patternScanResult!!.endIndex - 1
-            // Force the UI to behave like with a Premium account
-            mutableMethod.addInstruction(insertIndex,"const/4 v0, 0x2")
+            // Spoof a premium account
+            mutableMethod.addInstruction(insertIndex, "const/4 v0, 0x2")
         } ?: return OnDemandFingerprint.toErrorResult()
         return PatchResultSuccess()
     }


### PR DESCRIPTION
This patch tries to enable the on-demand feature of the Spotify Lite app (unlimited skips, play any song from any playlist/artist/album). Partially addresses: ReVanced/revanced-patches-template#1462

The patch **DOES NOT** remove any ads according to my testing. Should I indicate this in the patch description? Because people might get confused.

Also, is this correct when searching for a method with no parameters?
`parameters = listOf()`