### PR TITLE
fix(youtube/hide-video-action-buttons): fix 'hide share button'

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/patch/HideButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/patch/HideButtonsPatch.kt
@@ -64,13 +64,6 @@ class HideButtonsPatch : ResourcePatch {
                         false,
                         StringResource("revanced_hide_action_button_summary_on", "Buttons are hidden"),
                         StringResource("revanced_hide_action_button_summary_off", "Buttons are shown")
-                    ),
-                    SwitchPreference(
-                        "revanced_hide_share_button",
-                        StringResource("revanced_hide_share_button_title", "Hide share button"),
-                        false,
-                        StringResource("revanced_hide_share_button_summary_on", "Share button is hidden"),
-                        StringResource("revanced_hide_share_button_summaryoff", "Share button is shown")
                     )
                 ),
                 StringResource("revanced_hide_buttons_summary", "Hide or show buttons under videos")

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/patch/HideButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/patch/HideButtonsPatch.kt
@@ -60,10 +60,10 @@ class HideButtonsPatch : ResourcePatch {
                     ),
                     SwitchPreference(
                         "revanced_hide_action_button",
-                        StringResource("revanced_hide_action_button_title", "Hide create, clip and thanks buttons"),
+                        StringResource("revanced_hide_action_button_title", "Hide all other action buttons"),
                         false,
-                        StringResource("revanced_hide_action_button_summary_on", "Buttons are hidden"),
-                        StringResource("revanced_hide_action_button_summary_off", "Buttons are shown")
+                        StringResource("revanced_hide_action_button_summary_on", "Share, remix, clip, thanks, shop, live chat buttons are hidden"),
+                        StringResource("revanced_hide_action_button_summary_off", "Share, remix, clip, thanks, shop, live chat buttons are shown")
                     )
                 ),
                 StringResource("revanced_hide_buttons_summary", "Hide or show buttons under videos")

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/patch/HideButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/patch/HideButtonsPatch.kt
@@ -52,11 +52,11 @@ class HideButtonsPatch : ResourcePatch {
                         StringResource("revanced_hide_playlist_button_summary_off", "Playlist button is shown")
                     ),
                     SwitchPreference(
-                        "revanced_hide_action_button",
-                        StringResource("revanced_hide_action_button_title", "Hide all other action buttons"),
+                        "revanced_hide_action_buttons",
+                        StringResource("revanced_hide_action_buttons_title", "Hide all other action buttons"),
                         false,
-                        StringResource("revanced_hide_action_button_summary_on", "Share, remix, clip, thanks, shop, live chat buttons are hidden"),
-                        StringResource("revanced_hide_action_button_summary_off", "Share, remix, clip, thanks, shop, live chat buttons are shown")
+                        StringResource("revanced_hide_action_buttons_summary_on", "Share, remix, clip, thanks, shop, live chat buttons are hidden"),
+                        StringResource("revanced_hide_action_buttons_summary_off", "Share, remix, clip, thanks, shop, live chat buttons are shown")
                     )
                 ),
                 StringResource("revanced_hide_buttons_summary", "Hide or show buttons under videos")

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/patch/HideButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/patch/HideButtonsPatch.kt
@@ -31,18 +31,11 @@ class HideButtonsPatch : ResourcePatch {
                 StringResource("revanced_hide_buttons_title", "Hide action buttons"),
                 listOf(
                     SwitchPreference(
-                        "revanced_hide_like_button",
-                        StringResource("revanced_hide_like_button_title", "Hide like button"),
+                        "revanced_hide_like_dislike_button",
+                        StringResource("revanced_hide_like_dislike_button_title", "Hide like and dislike buttons"),
                         false,
-                        StringResource("revanced_hide_like_button_summary_on", "Like button is hidden"),
-                        StringResource("revanced_hide_like_button_summary_off", "Like button is shown")
-                    ),
-                    SwitchPreference(
-                        "revanced_hide_dislike_button",
-                        StringResource("revanced_hide_dislike_button_title", "Hide dislike button"),
-                        false,
-                        StringResource("revanced_hide_dislike_button_summary_on", "Dislike button is hidden"),
-                        StringResource("revanced_hide_dislike_button_summary_off", "Dislike button is shown")
+                        StringResource("revanced_hide_like_dislke_button_summary_on", "Like and dislike buttons are hidden"),
+                        StringResource("revanced_hide_like_dislike_button_summary_off", "Like and dislike buttons are shown")
                     ),
                     SwitchPreference(
                         "revanced_hide_download_button",

--- a/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/patch/HideButtonsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/layout/buttons/action/patch/HideButtonsPatch.kt
@@ -34,7 +34,7 @@ class HideButtonsPatch : ResourcePatch {
                         "revanced_hide_like_dislike_button",
                         StringResource("revanced_hide_like_dislike_button_title", "Hide like and dislike buttons"),
                         false,
-                        StringResource("revanced_hide_like_dislke_button_summary_on", "Like and dislike buttons are hidden"),
+                        StringResource("revanced_hide_like_dislike_button_summary_on", "Like and dislike buttons are hidden"),
                         StringResource("revanced_hide_like_dislike_button_summary_off", "Like and dislike buttons are shown")
                     ),
                     SwitchPreference(


### PR DESCRIPTION
Consolidated "hide share button" setting into the existing "hide action buttons" (change required to fix broken layout issues)

Consolidated "hide like" and "hide dislike" into a single setting.  Since most users have segmented like/dislikes and both must be hidden together.

![hide buttons](https://user-images.githubusercontent.com/118716522/233117076-295efeb1-1f56-4ce2-830a-dc1dc81ed8d2.png)


This PR appears to fix https://github.com/revanced/revanced-patches/issues/1863

[integration changes](https://github.com/revanced/revanced-integrations/pull/360)
