### PR TITLE
fix(youtube/minimized-playback): fix background play of kids videos

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/minimizedplayback/fingerprints/KidsMinimizedPlaybackPolicyControllerFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/minimizedplayback/fingerprints/KidsMinimizedPlaybackPolicyControllerFingerprint.kt
@@ -1,0 +1,23 @@
+package app.revanced.patches.youtube.misc.minimizedplayback.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object KidsMinimizedPlaybackPolicyControllerFingerprint : MethodFingerprint(
+    returnType = "V",
+    access = AccessFlags.PUBLIC or AccessFlags.FINAL,
+    parameters =  listOf("I", "L", "L"),
+    opcodes = listOf(
+        Opcode.IF_EQZ,
+        Opcode.SGET_OBJECT,
+        Opcode.IF_NE,
+        Opcode.CONST_4,
+        Opcode.IPUT_BOOLEAN,
+        Opcode.IF_EQZ,
+        Opcode.IGET,
+        Opcode.INVOKE_STATIC
+    ),
+    customFingerprint = { it.definingClass.endsWith("MinimizedPlaybackPolicyController;") }
+)

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/minimizedplayback/patch/MinimizedPlaybackPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/minimizedplayback/patch/MinimizedPlaybackPatch.kt
@@ -6,6 +6,7 @@ import app.revanced.patcher.annotation.Name
 import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.data.BytecodeContext
 import app.revanced.patcher.data.toMethodWalker
+import app.revanced.patcher.extensions.addInstruction
 import app.revanced.patcher.extensions.addInstructions
 import app.revanced.patcher.patch.BytecodePatch
 import app.revanced.patcher.patch.PatchResult
@@ -78,10 +79,9 @@ class MinimizedPlaybackPatch : BytecodePatch(
         // Force allowing background play for videos labeled for kids.
         // Some regions and YouTube accounts do not require this patch.
         KidsMinimizedPlaybackPolicyControllerFingerprint.result?.apply {
-            mutableMethod.addInstructions(
-                0, """
-                return-void
-                """
+            mutableMethod.addInstruction(
+                0,
+                "return-void"
             )
         } ?: return KidsMinimizedPlaybackPolicyControllerFingerprint.toErrorResult()
 

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/minimizedplayback/patch/MinimizedPlaybackPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/minimizedplayback/patch/MinimizedPlaybackPatch.kt
@@ -17,6 +17,7 @@ import app.revanced.patches.shared.settings.preference.impl.NonInteractivePrefer
 import app.revanced.patches.shared.settings.preference.impl.StringResource
 import app.revanced.patches.youtube.misc.integrations.patch.IntegrationsPatch
 import app.revanced.patches.youtube.misc.minimizedplayback.annotations.MinimizedPlaybackCompatibility
+import app.revanced.patches.youtube.misc.minimizedplayback.fingerprints.KidsMinimizedPlaybackPolicyControllerFingerprint
 import app.revanced.patches.youtube.misc.minimizedplayback.fingerprints.MinimizedPlaybackManagerFingerprint
 import app.revanced.patches.youtube.misc.minimizedplayback.fingerprints.MinimizedPlaybackSettingsFingerprint
 import app.revanced.patches.youtube.misc.playertype.patch.PlayerTypeHookPatch
@@ -33,7 +34,8 @@ import org.jf.dexlib2.iface.reference.MethodReference
 class MinimizedPlaybackPatch : BytecodePatch(
     listOf(
         MinimizedPlaybackManagerFingerprint,
-        MinimizedPlaybackSettingsFingerprint
+        MinimizedPlaybackSettingsFingerprint,
+        KidsMinimizedPlaybackPolicyControllerFingerprint
     )
 ) {
     override fun execute(context: BytecodeContext): PatchResult {
@@ -72,6 +74,16 @@ class MinimizedPlaybackPatch : BytecodePatch(
                 """
             )
         } ?: return MinimizedPlaybackSettingsFingerprint.toErrorResult()
+
+        // Force allowing background play for videos labeled for kids.
+        // Some regions and YouTube accounts do not require this patch.
+        KidsMinimizedPlaybackPolicyControllerFingerprint.result?.apply {
+            mutableMethod.addInstructions(
+                0, """
+                return-void
+                """
+            )
+        } ?: return KidsMinimizedPlaybackPolicyControllerFingerprint.toErrorResult()
 
         return PatchResultSuccess()
     }


### PR DESCRIPTION
Restored the kids background play patch that was removed in https://github.com/revanced/revanced-patches/pull/1990

Originally I did not see the issue because the kids video background play limitation applies only to certain regions (and in my country they don't make this restriction).

