### PR TITLE
fix(readme-generator): attempt to sort according to semantic version specification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,13 @@ repositories {
             password = githubPassword
         }
     }
+    // Required for FlexVer-Java
+    maven {
+        url = uri("https://repo.sleeping.town")
+        content {
+            includeGroup("com.unascribed")
+        }
+    }
 }
 
 dependencies {
@@ -24,6 +31,8 @@ dependencies {
     implementation("app.revanced:multidexlib2:2.5.3-a3836654")
     // Required for meta
     implementation("com.google.code.gson:gson:2.10.1")
+    // Required for FlexVer-Java
+    implementation("com.unascribed:flexver-java:1.0.2")
 }
 
 tasks {

--- a/src/main/kotlin/app/revanced/meta/ReadmeGenerator.kt
+++ b/src/main/kotlin/app/revanced/meta/ReadmeGenerator.kt
@@ -38,7 +38,6 @@ internal class ReadmeGenerator : PatchesFileGenerator {
                     }
                 }.let { commonMap ->
                     commonMap.maxByOrNull { it.value }?.value?.let {
-                        // Uses FlexVer (https://github.com/unascribed/FlexVer/) to perform version comparison
                         commonMap.entries.filter { mostCommon -> mostCommon.value == it }
                             .maxOfWith(FlexVerComparator::compare, Map.Entry<String, Int>::key)
                     } ?: "all"


### PR DESCRIPTION
Closes ReVanced/revanced-patches-template#1067 