### PR TITLE
fix(youtube/remember-video-quality): fix default video quality/speed being applied when resuming app.

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/misc/video/information/patch/VideoInformationPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/video/information/patch/VideoInformationPatch.kt
@@ -160,24 +160,32 @@ class VideoInformationPatch : BytecodePatch(
         private const val INTEGRATIONS_CLASS_DESCRIPTOR = "Lapp/revanced/integrations/patches/VideoInformation;"
 
         private lateinit var playerInitMethod: MutableMethod
+        private var playerInitInsertIndex = 4
+
         private lateinit var timeMethod: MutableMethod
+        private var timeInitInsertIndex = 2
+
         private lateinit var highPrecisionTimeMethod: MutableMethod
+        private var highPrecisionInsertIndex = 0
 
-        private fun MutableMethod.insert(insert: InsertIndex, register: String, descriptor: String) =
-            addInstruction(insert.index, "invoke-static { $register }, $descriptor")
+        private fun MutableMethod.insert(insertIndex: Int, register: String, descriptor: String) =
+            addInstruction(insertIndex, "invoke-static { $register }, $descriptor")
 
-        private fun MutableMethod.insertTimeHook(insert: InsertIndex, descriptor: String) =
-            insert(insert, "p1, p2", descriptor)
+        private fun MutableMethod.insertTimeHook(insertIndex: Int, descriptor: String) =
+            insert(insertIndex, "p1, p2", descriptor)
 
         /**
-         * Hook the player controller.
+         * Hook the player controller.  Called when a video is opened or the current video is changed.
+         *
+         * Note: This hook is called very early and is called before the video id, video time, video length,
+         * and many other data fields are set.
          *
          * @param targetMethodClass The descriptor for the class to invoke when the player controller is created.
          * @param targetMethodName The name of the static method to invoke when the player controller is created.
          */
         internal fun onCreateHook(targetMethodClass: String, targetMethodName: String) =
             playerInitMethod.insert(
-                InsertIndex.CREATE,
+                playerInitInsertIndex++,
                 "v0",
                 "$targetMethodClass->$targetMethodName(Ljava/lang/Object;)V"
             )
@@ -191,7 +199,7 @@ class VideoInformationPatch : BytecodePatch(
          */
         internal fun videoTimeHook(targetMethodClass: String, targetMethodName: String) =
             timeMethod.insertTimeHook(
-                InsertIndex.TIME,
+                timeInitInsertIndex++,
                 "$targetMethodClass->$targetMethodName(J)V"
             )
 
@@ -205,15 +213,9 @@ class VideoInformationPatch : BytecodePatch(
          */
         internal fun highPrecisionTimeHook(targetMethodClass: String, targetMethodName: String) =
             highPrecisionTimeMethod.insertTimeHook(
-                InsertIndex.HIGH_PRECISION_TIME,
+                highPrecisionInsertIndex++,
                 "$targetMethodClass->$targetMethodName(J)V"
             )
-
-        enum class InsertIndex(internal val index: Int) {
-            CREATE(4),
-            TIME(2),
-            HIGH_PRECISION_TIME(0),
-        }
 
         private fun getReference(instructions: List<BuilderInstruction>, offset: Int, opcode: Opcode) =
             instructions[instructions.indexOfFirst { it.opcode == opcode } + offset].reference

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/video/quality/patch/RememberVideoQualityPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/video/quality/patch/RememberVideoQualityPatch.kt
@@ -20,16 +20,16 @@ import app.revanced.patches.shared.settings.preference.impl.StringResource
 import app.revanced.patches.shared.settings.preference.impl.SwitchPreference
 import app.revanced.patches.youtube.misc.integrations.patch.IntegrationsPatch
 import app.revanced.patches.youtube.misc.settings.bytecode.patch.SettingsPatch
+import app.revanced.patches.youtube.misc.video.information.patch.VideoInformationPatch
 import app.revanced.patches.youtube.misc.video.quality.annotations.RememberVideoQualityCompatibility
 import app.revanced.patches.youtube.misc.video.quality.fingerprints.SetQualityByIndexMethodClassFieldReferenceFingerprint
 import app.revanced.patches.youtube.misc.video.quality.fingerprints.VideoQualityItemOnClickParentFingerprint
 import app.revanced.patches.youtube.misc.video.quality.fingerprints.VideoQualitySetterFingerprint
-import app.revanced.patches.youtube.misc.video.videoid.patch.VideoIdPatch
 import org.jf.dexlib2.iface.instruction.ReferenceInstruction
 import org.jf.dexlib2.iface.reference.FieldReference
 
 @Patch
-@DependsOn([IntegrationsPatch::class, VideoIdPatch::class, SettingsPatch::class])
+@DependsOn([IntegrationsPatch::class, VideoInformationPatch::class, SettingsPatch::class])
 @Name("remember-video-quality")
 @Description("Adds the ability to remember the video quality you chose in the video quality flyout.")
 @RememberVideoQualityCompatibility
@@ -114,7 +114,7 @@ class RememberVideoQualityPatch : BytecodePatch(
          * Conveniently, at this point the video quality is overridden to the remembered playback speed.
          */
 
-        VideoIdPatch.injectCall("$INTEGRATIONS_CLASS_DESCRIPTOR->newVideoStarted(Ljava/lang/String;)V")
+        VideoInformationPatch.onCreateHook(INTEGRATIONS_CLASS_DESCRIPTOR, "newVideoStarted")
 
         // Inject a call to set the remembered quality once a video loads.
         VideoQualitySetterFingerprint.result?.also {

--- a/src/main/kotlin/app/revanced/patches/youtube/misc/video/speed/remember/patch/RememberPlaybackSpeedPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/misc/video/speed/remember/patch/RememberPlaybackSpeedPatch.kt
@@ -23,12 +23,11 @@ import app.revanced.patches.youtube.misc.video.information.patch.VideoInformatio
 import app.revanced.patches.youtube.misc.video.information.patch.VideoInformationPatch.Companion.reference
 import app.revanced.patches.youtube.misc.video.speed.remember.annotation.RememberPlaybackSpeedCompatibility
 import app.revanced.patches.youtube.misc.video.speed.remember.fingerprint.InitializePlaybackSpeedValuesFingerprint
-import app.revanced.patches.youtube.misc.video.videoid.patch.VideoIdPatch
 
 @Patch
 @Name("remember-playback-speed")
 @Description("Adds the ability to remember the playback speed you chose in the video playback speed flyout.")
-@DependsOn([IntegrationsPatch::class, SettingsPatch::class, VideoIdPatch::class, VideoInformationPatch::class])
+@DependsOn([IntegrationsPatch::class, SettingsPatch::class, VideoInformationPatch::class])
 @RememberPlaybackSpeedCompatibility
 @Version("0.0.1")
 class RememberPlaybackSpeedPatch : BytecodePatch(
@@ -77,8 +76,7 @@ class RememberPlaybackSpeedPatch : BytecodePatch(
             )
         )
 
-        VideoIdPatch.injectCall("${INTEGRATIONS_CLASS_DESCRIPTOR}->newVideoLoaded(Ljava/lang/String;)V")
-
+        VideoInformationPatch.onCreateHook(INTEGRATIONS_CLASS_DESCRIPTOR, "newVideoStarted")
         VideoInformationPatch.userSelectedPlaybackSpeedHook(
             INTEGRATIONS_CLASS_DESCRIPTOR, "userSelectedPlaybackSpeed")
 


### PR DESCRIPTION
Changed to the video player initialization hook, which is called only when opening/changing videos.


Fixes https://github.com/revanced/revanced-patches/issues/2053

[integration changes](https://github.com/revanced/revanced-integrations/pull/392)
