### PR TITLE
fix(photomath/unlock-plus): constrain to last working version

### DIFF
--- a/src/main/kotlin/app/revanced/patches/memegenerator/misc/pro/annotations/UnlockProCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/memegenerator/misc/pro/annotations/UnlockProCompatibility.kt
@@ -3,6 +3,15 @@ package app.revanced.patches.memegenerator.misc.pro.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("com.zombodroid.MemeGenerator", arrayOf("4.6364"))])
+@Compatibility(
+    [Package(
+        "com.zombodroid.MemeGenerator", arrayOf(
+            "4.6364",
+            "4.6370",
+            "4.6375",
+            "4.6377",
+        )
+    )]
+)
 @Target(AnnotationTarget.CLASS)
 internal annotation class UnlockProCompatibility

--- a/src/main/kotlin/app/revanced/patches/memegenerator/misc/pro/annotations/UnlockProCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/memegenerator/misc/pro/annotations/UnlockProCompatibility.kt
@@ -3,15 +3,6 @@ package app.revanced.patches.memegenerator.misc.pro.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility(
-    [Package(
-        "com.zombodroid.MemeGenerator", arrayOf(
-            "4.6364",
-            "4.6370",
-            "4.6375",
-            "4.6377",
-        )
-    )]
-)
+@Compatibility([Package("com.zombodroid.MemeGenerator", arrayOf("4.6364"))])
 @Target(AnnotationTarget.CLASS)
 internal annotation class UnlockProCompatibility

--- a/src/main/kotlin/app/revanced/patches/photomath/misc/unlockplus/annotations/UnlockPlusCompatibilty.kt
+++ b/src/main/kotlin/app/revanced/patches/photomath/misc/unlockplus/annotations/UnlockPlusCompatibilty.kt
@@ -1,0 +1,30 @@
+package app.revanced.patches.photomath.misc.unlockplus.annotations
+
+import app.revanced.patcher.annotation.Compatibility
+import app.revanced.patcher.annotation.Package
+
+@Compatibility(
+    [Package(
+        "com.microblink.photomath", arrayOf(
+            "8.6.0",
+            "8.7.0",
+            "8.8.0",
+            "8.9.0",
+            "8.10.0",
+            "8.11.0",
+            "8.12.0",
+            "8.13.0",
+            "8.14.0",
+            "8.15.0",
+            "8.16.0",
+            "8.17.0",
+            "8.18.0",
+            "8.18.1",
+            "8.19.0",
+            "8.20.0",
+            "8.21.0",
+        )
+    )]
+)
+@Target(AnnotationTarget.CLASS)
+internal annotation class UnlockPlusCompatibilty

--- a/src/main/kotlin/app/revanced/patches/photomath/misc/unlockplus/annotations/UnlockPlusCompatibilty.kt
+++ b/src/main/kotlin/app/revanced/patches/photomath/misc/unlockplus/annotations/UnlockPlusCompatibilty.kt
@@ -22,7 +22,6 @@ import app.revanced.patcher.annotation.Package
             "8.18.1",
             "8.19.0",
             "8.20.0",
-            "8.21.0",
         )
     )]
 )

--- a/src/main/kotlin/app/revanced/patches/photomath/misc/unlockplus/annotations/UnlockPlusCompatibilty.kt
+++ b/src/main/kotlin/app/revanced/patches/photomath/misc/unlockplus/annotations/UnlockPlusCompatibilty.kt
@@ -3,27 +3,6 @@ package app.revanced.patches.photomath.misc.unlockplus.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility(
-    [Package(
-        "com.microblink.photomath", arrayOf(
-            "8.6.0",
-            "8.7.0",
-            "8.8.0",
-            "8.9.0",
-            "8.10.0",
-            "8.11.0",
-            "8.12.0",
-            "8.13.0",
-            "8.14.0",
-            "8.15.0",
-            "8.16.0",
-            "8.17.0",
-            "8.18.0",
-            "8.18.1",
-            "8.19.0",
-            "8.20.0",
-        )
-    )]
-)
+@Compatibility([Package("com.microblink.photomath", arrayOf("8.20.0"))])
 @Target(AnnotationTarget.CLASS)
 internal annotation class UnlockPlusCompatibilty

--- a/src/main/kotlin/app/revanced/patches/photomath/misc/unlockplus/patch/UnlockPlusPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/photomath/misc/unlockplus/patch/UnlockPlusPatch.kt
@@ -1,10 +1,8 @@
 package app.revanced.patches.photomath.misc.unlockplus.patch
 
 import app.revanced.extensions.toErrorResult
-import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Description
 import app.revanced.patcher.annotation.Name
-import app.revanced.patcher.annotation.Package
 import app.revanced.patcher.annotation.Version
 import app.revanced.patcher.data.BytecodeContext
 import app.revanced.patcher.extensions.addInstructions
@@ -14,13 +12,14 @@ import app.revanced.patcher.patch.PatchResultSuccess
 import app.revanced.patcher.patch.annotations.DependsOn
 import app.revanced.patcher.patch.annotations.Patch
 import app.revanced.patches.photomath.detection.signature.patch.SignatureDetectionPatch
+import app.revanced.patches.photomath.misc.unlockplus.annotations.UnlockPlusCompatibilty
 import app.revanced.patches.photomath.misc.unlockplus.fingerprints.IsPlusUnlockedFingerprint
 
 @Patch
 @Name("unlock-plus")
 @DependsOn([SignatureDetectionPatch::class])
 @Description("Unlocks plus features.")
-@Compatibility([Package("com.microblink.photomath")])
+@UnlockPlusCompatibilty
 @Version("0.0.1")
 class UnlockPlusPatch : BytecodePatch(
     listOf(


### PR DESCRIPTION
Constrain app version to resolve partial incompatibility of newest versions. 

https://github.com/revanced/revanced-patches/issues/2196