### PR TITLE
feat: universal `remove-screen-capture-restriction` patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/all/screencapture/removerestriction/bytecode/patch/RemoveCaptureRestrictionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/all/screencapture/removerestriction/bytecode/patch/RemoveCaptureRestrictionPatch.kt
@@ -7,7 +7,7 @@ import app.revanced.patcher.patch.annotations.DependsOn
 import app.revanced.patcher.patch.annotations.Patch
 import app.revanced.patcher.patch.annotations.RequiresIntegrations
 import app.revanced.patcher.util.proxy.mutableTypes.MutableMethod
-import app.revanced.patches.all.screencapture.removerestriction.resources.patch.RemoveCaptureRestrictionResourcePatch
+import app.revanced.patches.all.screencapture.removerestriction.resource.patch.RemoveCaptureRestrictionResourcePatch
 import app.revanced.util.patch.*
 import org.jf.dexlib2.iface.ClassDef
 import org.jf.dexlib2.iface.Method

--- a/src/main/kotlin/app/revanced/patches/all/screencapture/removerestriction/bytecode/patch/RemoveCaptureRestrictionPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/all/screencapture/removerestriction/bytecode/patch/RemoveCaptureRestrictionPatch.kt
@@ -1,0 +1,67 @@
+package app.revanced.patches.all.screencapture.removerestriction.bytecode.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.patch.annotations.DependsOn
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patcher.patch.annotations.RequiresIntegrations
+import app.revanced.patcher.util.proxy.mutableTypes.MutableMethod
+import app.revanced.patches.all.screencapture.removerestriction.resources.patch.RemoveCaptureRestrictionResourcePatch
+import app.revanced.util.patch.*
+import org.jf.dexlib2.iface.ClassDef
+import org.jf.dexlib2.iface.Method
+import org.jf.dexlib2.iface.instruction.Instruction
+
+@Patch(false)
+@Name("remove-screen-capture-restriction")
+@Description("Removes the restriction of capturing apps that normally wouldn't allow it.")
+@Version("0.0.1")
+@DependsOn([RemoveCaptureRestrictionResourcePatch::class])
+@RequiresIntegrations
+internal class RemoveCaptureRestrictionPatch : AbstractTransformInstructionsPatch<Instruction35cInfo>() {
+
+    private companion object {
+        const val INTEGRATIONS_CLASS_DESCRIPTOR_PREFIX =
+            "Lapp/revanced/all/screencapture/removerestriction/RemoveScreencaptureRestrictionPatch"
+        const val INTEGRATIONS_CLASS_DESCRIPTOR = "$INTEGRATIONS_CLASS_DESCRIPTOR_PREFIX;"
+    }
+
+    // Information about method calls we want to replace
+    enum class MethodCall(
+        override val definedClassName: String,
+        override val methodName: String,
+        override val methodParams: Array<String>,
+        override val returnType: String
+    ): IMethodCall {
+        SetAllowedCapturePolicySingle(
+            "Landroid/media/AudioAttributes\$Builder;",
+            "setAllowedCapturePolicy",
+            arrayOf("I"),
+            "Landroid/media/AudioAttributes\$Builder;",
+        ),
+        SetAllowedCapturePolicyGlobal(
+            "Landroid/media/AudioManager;",
+            "setAllowedCapturePolicy",
+            arrayOf("I"),
+            "V",
+        );
+    }
+
+    override fun filterMap(
+        classDef: ClassDef,
+        method: Method,
+        instruction: Instruction,
+        instructionIndex: Int
+    ) = filterMapInstruction35c<MethodCall>(
+        INTEGRATIONS_CLASS_DESCRIPTOR_PREFIX,
+        classDef,
+        instruction,
+        instructionIndex
+    )
+
+    override fun transform(mutableMethod: MutableMethod, entry: Instruction35cInfo) {
+        val (methodType, instruction, instructionIndex) = entry
+        methodType.replaceInvokeVirtualWithIntegrations(INTEGRATIONS_CLASS_DESCRIPTOR, mutableMethod, instruction, instructionIndex)
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/all/screencapture/removerestriction/resource/patch/RemoveCaptureRestrictionResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/all/screencapture/removerestriction/resource/patch/RemoveCaptureRestrictionResourcePatch.kt
@@ -1,4 +1,4 @@
-package app.revanced.patches.all.screencapture.removerestriction.resources.patch
+package app.revanced.patches.all.screencapture.removerestriction.resource.patch
 
 import app.revanced.patcher.annotation.Description
 import app.revanced.patcher.annotation.Name
@@ -12,7 +12,7 @@ import org.w3c.dom.Element
 @Name("remove-screen-capture-restriction-resource-patch")
 @Description("Sets allowAudioPlaybackCapture in manifest to true.")
 @Version("0.0.1")
-class RemoveCaptureRestrictionResourcePatch : ResourcePatch {
+internal class RemoveCaptureRestrictionResourcePatch : ResourcePatch {
     override fun execute(context: ResourceContext): PatchResult {
         // create an xml editor instance
         context.xmlEditor["AndroidManifest.xml"].use { dom ->

--- a/src/main/kotlin/app/revanced/patches/all/screencapture/removerestriction/resources/patch/RemoveCaptureRestrictionResourcePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/all/screencapture/removerestriction/resources/patch/RemoveCaptureRestrictionResourcePatch.kt
@@ -1,0 +1,31 @@
+package app.revanced.patches.all.screencapture.removerestriction.resources.patch
+
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.annotation.Version
+import app.revanced.patcher.data.ResourceContext
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.ResourcePatch
+import org.w3c.dom.Element
+
+@Name("remove-screen-capture-restriction-resource-patch")
+@Description("Sets allowAudioPlaybackCapture in manifest to true.")
+@Version("0.0.1")
+class RemoveCaptureRestrictionResourcePatch : ResourcePatch {
+    override fun execute(context: ResourceContext): PatchResult {
+        // create an xml editor instance
+        context.xmlEditor["AndroidManifest.xml"].use { dom ->
+            // get the application node
+            val applicationNode = dom
+                .file
+                .getElementsByTagName("application")
+                .item(0) as Element
+
+            // set allowAudioPlaybackCapture attribute to true
+            applicationNode.setAttribute("android:allowAudioPlaybackCapture", "true")
+        }
+
+        return PatchResultSuccess()
+    }
+}


### PR DESCRIPTION
This patch disables screen/audio capture restrictions often used for DRM-related reasons. It supersedes my old patch that only worked with Spotify.

Depends on https://github.com/revanced/revanced-integrations/pull/410.