### PR TITLE
feat(YouTube Music): Add `Permanent repeat` patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/interaction/permanentrepeat/fingerprints/PermanentRepeatFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/music/interaction/permanentrepeat/fingerprints/PermanentRepeatFingerprint.kt
@@ -1,0 +1,22 @@
+package app.revanced.patches.music.interaction.permanentrepeat.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object PermanentRepeatFingerprint : MethodFingerprint(
+    "V",
+    AccessFlags.PUBLIC or AccessFlags.FINAL,
+    listOf("L", "L"),
+    listOf(
+        Opcode.CHECK_CAST,
+        Opcode.INVOKE_INTERFACE,
+        Opcode.IGET_OBJECT,
+        Opcode.IGET_OBJECT,
+        Opcode.SGET_OBJECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT,
+        Opcode.IF_NEZ
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/music/interaction/permanentrepeat/fingerprints/RepeatTrackFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/music/interaction/permanentrepeat/fingerprints/RepeatTrackFingerprint.kt
@@ -5,7 +5,7 @@ import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
 import org.jf.dexlib2.AccessFlags
 import org.jf.dexlib2.Opcode
 
-object PermanentRepeatFingerprint : MethodFingerprint(
+object RepeatTrackFingerprint : MethodFingerprint(
     "V",
     AccessFlags.PUBLIC or AccessFlags.FINAL,
     listOf("L", "L"),

--- a/src/main/kotlin/app/revanced/patches/music/interaction/permanentrepeat/patch/PermanentRepeatPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/interaction/permanentrepeat/patch/PermanentRepeatPatch.kt
@@ -10,30 +10,30 @@ import app.revanced.patcher.patch.BytecodePatch
 import app.revanced.patcher.patch.PatchResult
 import app.revanced.patcher.patch.PatchResultSuccess
 import app.revanced.patcher.patch.annotations.Patch
-import app.revanced.patches.music.annotations.MusicCompatibility
-import app.revanced.patches.music.interaction.permanentrepeat.fingerprints.PermanentRepeatFingerprint
 import app.revanced.patcher.util.smali.ExternalLabel
+import app.revanced.patches.music.annotations.MusicCompatibility
+import app.revanced.patches.music.interaction.permanentrepeat.fingerprints.RepeatTrackFingerprint
 
 @Patch(false)
 @Name("Permanent repeat")
 @Description("Permanently remember your repeating preference even if the playlist ends or another track is played.")
 @MusicCompatibility
 class PermanentRepeatPatch : BytecodePatch(
-    listOf(PermanentRepeatFingerprint)
+    listOf(RepeatTrackFingerprint)
 ) {
     override fun execute(context: BytecodeContext): PatchResult {
-        PermanentRepeatFingerprint.result?.let {
-            val startIndex = it.scanResult.patternScanResult!!.endIndex;
-            val repeatIndex = startIndex + 3;
+        RepeatTrackFingerprint.result?.let {
+            val startIndex = it.scanResult.patternScanResult!!.endIndex
+            val repeatIndex = startIndex + 3
 
-            it.mutableMethod.also {
-                it.addInstructionsWithLabels(
+            it.mutableMethod.apply {
+                addInstructionsWithLabels(
                     startIndex,
                     "goto :repeat",
-                    ExternalLabel("repeat", it.getInstruction(repeatIndex))
+                    ExternalLabel("repeat", getInstruction(repeatIndex))
                 )
             }
-        } ?: return PermanentRepeatFingerprint.toErrorResult()
+        } ?: return RepeatTrackFingerprint.toErrorResult()
 
         return PatchResultSuccess()
     }

--- a/src/main/kotlin/app/revanced/patches/music/interaction/permanentrepeat/patch/PermanentRepeatPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/interaction/permanentrepeat/patch/PermanentRepeatPatch.kt
@@ -1,0 +1,40 @@
+package app.revanced.patches.music.interaction.permanentrepeat.patch
+
+import app.revanced.extensions.toErrorResult
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.music.annotations.MusicCompatibility
+import app.revanced.patches.music.interaction.permanentrepeat.fingerprints.PermanentRepeatFingerprint
+import app.revanced.patcher.util.smali.ExternalLabel
+
+@Patch(false)
+@Name("Permanent repeat")
+@Description("Permanently remember your repeating preference even if the playlist ends or another track is played.")
+@MusicCompatibility
+class PermanentRepeatPatch : BytecodePatch(
+    listOf(PermanentRepeatFingerprint)
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        PermanentRepeatFingerprint.result?.let {
+            val startIndex = it.scanResult.patternScanResult!!.endIndex;
+            val repeatIndex = startIndex + 3;
+
+            it.mutableMethod.also {
+                it.addInstructionsWithLabels(
+                    startIndex,
+                    "goto :repeat",
+                    ExternalLabel("repeat", it.getInstruction(repeatIndex))
+                )
+            }
+        } ?: return PermanentRepeatFingerprint.toErrorResult()
+
+        return PatchResultSuccess()
+    }
+}


### PR DESCRIPTION
To partially resolve ReVanced/revanced-patches-template#1576 for YouTube Music this adds permanent repeat to YouTube music. When the patch is enabled, the repeat button will stay enabled until it is manually disabled.

Because the repeat button is part of the layout, I put the patch in the `layout/` directory, but I am not sure if that is actually the best place for it.

Goes along with ReVanced/revanced-patches#2730, since both patches are nearly identical I'll apply any requested changes to both.
No integrations for this patch.