### PR TITLE
feat(YouTube Music): Add `Permanent Shuffle` patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/interaction/permanentshuffle/fingerprints/DisableShuffleFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/music/interaction/permanentshuffle/fingerprints/DisableShuffleFingerprint.kt
@@ -1,0 +1,20 @@
+package app.revanced.patches.music.interaction.permanentshuffle.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.method.impl.MethodFingerprint
+import org.jf.dexlib2.AccessFlags
+import org.jf.dexlib2.Opcode
+
+object DisableShuffleFingerprint : MethodFingerprint(
+    "V",
+    AccessFlags.PUBLIC or AccessFlags.FINAL,
+    listOf(),
+    listOf(
+        Opcode.IGET_OBJECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.SGET_OBJECT,
+        Opcode.IPUT_OBJECT,
+        Opcode.IGET_OBJECT,
+        Opcode.INVOKE_VIRTUAL
+    )
+)

--- a/src/main/kotlin/app/revanced/patches/music/interaction/permanentshuffle/patch/PermanentShufflePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/interaction/permanentshuffle/patch/PermanentShufflePatch.kt
@@ -1,0 +1,32 @@
+package app.revanced.patches.music.interaction.permanentshuffle.patch
+
+import app.revanced.extensions.toErrorResult
+import app.revanced.patcher.annotation.Description
+import app.revanced.patcher.annotation.Name
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstruction
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.PatchResult
+import app.revanced.patcher.patch.PatchResultSuccess
+import app.revanced.patcher.patch.annotations.Patch
+import app.revanced.patches.music.annotations.MusicCompatibility
+import app.revanced.patches.music.interaction.permanentshuffle.fingerprints.DisableShuffleFingerprint
+import app.revanced.patcher.util.smali.ExternalLabel
+
+@Patch(false)
+@Name("Permanent shuffle")
+@Description("Permanently remember your shuffle preference even if the playlist ends or another track is played.")
+@MusicCompatibility
+class PermanentShuffleTogglePatch : BytecodePatch(
+    listOf(DisableShuffleFingerprint)
+) {
+    override fun execute(context: BytecodeContext): PatchResult {
+        DisableShuffleFingerprint.result?.let {
+            it.mutableMethod.also {
+                it.addInstruction(0, "return-void")
+            }
+        } ?: return DisableShuffleFingerprint.toErrorResult()
+
+        return PatchResultSuccess()
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/music/interaction/permanentshuffle/patch/PermanentShufflePatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/interaction/permanentshuffle/patch/PermanentShufflePatch.kt
@@ -11,21 +11,18 @@ import app.revanced.patcher.patch.PatchResultSuccess
 import app.revanced.patcher.patch.annotations.Patch
 import app.revanced.patches.music.annotations.MusicCompatibility
 import app.revanced.patches.music.interaction.permanentshuffle.fingerprints.DisableShuffleFingerprint
-import app.revanced.patcher.util.smali.ExternalLabel
 
 @Patch(false)
 @Name("Permanent shuffle")
-@Description("Permanently remember your shuffle preference even if the playlist ends or another track is played.")
+@Description("Permanently remember your shuffle preference " +
+        "even if the playlist ends or another track is played.")
 @MusicCompatibility
 class PermanentShuffleTogglePatch : BytecodePatch(
     listOf(DisableShuffleFingerprint)
 ) {
     override fun execute(context: BytecodeContext): PatchResult {
-        DisableShuffleFingerprint.result?.let {
-            it.mutableMethod.also {
-                it.addInstruction(0, "return-void")
-            }
-        } ?: return DisableShuffleFingerprint.toErrorResult()
+        DisableShuffleFingerprint.result?.mutableMethod?.addInstruction(0, "return-void")
+            ?: return DisableShuffleFingerprint.toErrorResult()
 
         return PatchResultSuccess()
     }


### PR DESCRIPTION
To partially resolve https://github.com/ReVanced/revanced-patches-template/issues/1576 for YouTube Music this adds permanent shuffle to YouTube music. When the patch is enabled, the shuffle button will stay enabled until it is manually disabled.

Because the shuffle button is part of the layout, I put the patch in the layout/ directory, but I am not sure if that is actually the best place for it.

Goes along with ReVanced/revanced-patches#2722.
No integrations for this patch.