### PR TITLE
feat(Twitch): Support version `16.1.0`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitch/ad/embedded/annotations/EmbeddedAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/embedded/annotations/EmbeddedAdsCompatibility.kt
@@ -3,7 +3,7 @@ package app.revanced.patches.twitch.ad.embedded.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("tv.twitch.android.app", arrayOf("15.4.1"))])
+@Compatibility([Package("tv.twitch.android.app", arrayOf("15.4.1", "16.1.0"))])
 @Target(AnnotationTarget.CLASS)
 internal annotation class EmbeddedAdsCompatibility
 

--- a/src/main/kotlin/app/revanced/patches/twitch/ad/video/annotations/VideoAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/video/annotations/VideoAdsCompatibility.kt
@@ -3,7 +3,7 @@ package app.revanced.patches.twitch.ad.video.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("tv.twitch.android.app", arrayOf("15.4.1"))])
+@Compatibility([Package("tv.twitch.android.app", arrayOf("15.4.1", "16.1.0"))])
 @Target(AnnotationTarget.CLASS)
 internal annotation class VideoAdsCompatibility
 

--- a/src/main/kotlin/app/revanced/patches/twitch/chat/antidelete/annotations/ShowDeletedMessagesCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/chat/antidelete/annotations/ShowDeletedMessagesCompatibility.kt
@@ -3,7 +3,7 @@ package app.revanced.patches.twitch.chat.antidelete.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("tv.twitch.android.app", arrayOf("15.4.1"))])
+@Compatibility([Package("tv.twitch.android.app", arrayOf("15.4.1", "16.1.0"))])
 @Target(AnnotationTarget.CLASS)
 internal annotation class ShowDeletedMessagesCompatibility
 

--- a/src/main/kotlin/app/revanced/patches/twitch/chat/autoclaim/annotations/AutoClaimChannelPointsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/chat/autoclaim/annotations/AutoClaimChannelPointsCompatibility.kt
@@ -3,6 +3,6 @@ package app.revanced.patches.twitch.chat.autoclaim.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("tv.twitch.android.app", arrayOf("15.4.1"))])
+@Compatibility([Package("tv.twitch.android.app", arrayOf("15.4.1", "16.1.0"))])
 @Target(AnnotationTarget.CLASS)
 internal annotation class AutoClaimChannelPointsCompatibility


### PR DESCRIPTION
Now supports version `16.1.0` of Twitch.

- No changes to the patches themselves needed to be made.