### PR TITLE
fix(Twitch - Audio ads): Support missing version `16.1.0`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitch/ad/audio/annotations/AudioAdsCompatibility.kt
+++ b/src/main/kotlin/app/revanced/patches/twitch/ad/audio/annotations/AudioAdsCompatibility.kt
@@ -3,7 +3,7 @@ package app.revanced.patches.twitch.ad.audio.annotations
 import app.revanced.patcher.annotation.Compatibility
 import app.revanced.patcher.annotation.Package
 
-@Compatibility([Package("tv.twitch.android.app", arrayOf("15.4.1"))])
+@Compatibility([Package("tv.twitch.android.app", arrayOf("15.4.1", "16.1.0"))])
 @Target(AnnotationTarget.CLASS)
 internal annotation class AudioAdsCompatibility
 


### PR DESCRIPTION
While updating Twitch to `16.1.0` I forgot to update the audio ads patch.