### PR TITLE
fix(Duolingo - Unlock Super): Correct instruction offset

### DIFF
--- a/src/main/kotlin/app/revanced/patches/duolingo/unlocksuper/UnlockDuolingoSuperPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/duolingo/unlocksuper/UnlockDuolingoSuperPatch.kt
@@ -54,8 +54,8 @@ object UnlockDuolingoSuperPatch : BytecodePatch(
     }
 
     private fun MutableMethod.indexOfReference(reference: Reference) = getInstructions()
-        .filterIsInstance<BuilderInstruction22c>()
-        .filter { it.opcode == Opcode.IPUT_BOOLEAN }.indexOfFirst { it.reference == reference }.let {
+        .indexOfFirst { it is BuilderInstruction22c && it.opcode == Opcode.IPUT_BOOLEAN && it.reference == reference }
+        .let {
             if (it == -1) throw PatchException("Could not find index of instruction with supplied reference.")
             else it
         }


### PR DESCRIPTION
This PR fixes ReVanced/revanced-patches#2892 and ReVanced/revanced-patches-template#374.
No integration.

The offset used to replace instructions was incorrect because of the filters.

Disclaimer: I'm a Kotlin noob so this might not be the best or cleanest solution.