### PR TITLE
feat(OpeningHours): fix crash

### DIFF
--- a/src/main/kotlin/app/revanced/patches/openinghours/crash/CrashPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/openinghours/crash/CrashPatch.kt
@@ -1,0 +1,85 @@
+package app.revanced.patches.openinghours.crash
+
+import app.revanced.extensions.exception
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
+import app.revanced.patcher.extensions.InstructionExtensions.removeInstructions
+import app.revanced.patcher.patch.BytecodePatch
+import app.revanced.patcher.patch.annotation.CompatiblePackage
+import app.revanced.patcher.patch.annotation.Patch
+import app.revanced.patcher.util.smali.ExternalLabel
+import app.revanced.patches.openinghours.crash.fingerprints.SetPlaceFingerprint
+import com.android.tools.smali.dexlib2.builder.BuilderInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+@Patch(
+    name = "Fix crash",
+    compatiblePackages = [CompatiblePackage("de.simon.openinghours", ["1.0"])]
+)
+object CrashPatch : BytecodePatch(setOf(SetPlaceFingerprint)) {
+
+    override fun execute(context: BytecodeContext) {
+        with(SetPlaceFingerprint.result ?: throw SetPlaceFingerprint.exception) {
+            val indexedInstructions = mutableMethod.implementation!!.instructions.withIndex().toList()
+            val getOpeningHoursIndex = getIndicesOfInvoke(indexedInstructions, "Lde/simon/openinghours/models/Place;", "getOpeningHours")
+            val setWeekDayTextIndex = getIndicesOfInvoke(indexedInstructions, "Lde/simon/openinghours/views/custom/PlaceCard;", "setWeekDayText")[0]
+            val startCalculateStatusIndex = getIndicesOfInvoke(indexedInstructions, "Lde/simon/openinghours/views/custom/PlaceCard;", "startCalculateStatus")[0]
+            val getOpeningHoursIndex1 = getOpeningHoursIndex[0]
+            val getOpeningHoursIndex2 = getOpeningHoursIndex[1]
+            val continueLabel2 = ExternalLabel("continue_1", mutableMethod.getInstruction(startCalculateStatusIndex + 1))
+
+            mutableMethod.removeInstructions(getOpeningHoursIndex2, startCalculateStatusIndex - getOpeningHoursIndex2 + 1)
+            mutableMethod.addInstructionsWithLabels(
+                getOpeningHoursIndex2,
+                """
+                    invoke-virtual {p1}, Lde/simon/openinghours/models/Place;->getOpeningHours()Lde/simon/openinghours/models/OpeningHours;
+                    move-result-object p1
+                    if-eqz p1, :continue_1
+                    invoke-virtual {p1}, Lde/simon/openinghours/models/OpeningHours;->getPeriods()Lio/realm/RealmList;
+                    move-result-object p1
+                    if-eqz p1, :continue_1
+                    check-cast p1, Ljava/util/List;
+                    invoke-direct {p0, p1}, Lde/simon/openinghours/views/custom/PlaceCard;->startCalculateStatus(Ljava/util/List;)V
+                """,
+                continueLabel2,
+            )
+
+            val continueLabel1 = ExternalLabel("continue_0", mutableMethod.getInstruction(setWeekDayTextIndex + 1))
+
+            mutableMethod.removeInstructions(getOpeningHoursIndex1, setWeekDayTextIndex - getOpeningHoursIndex1 + 1)
+            mutableMethod.addInstructionsWithLabels(
+                getOpeningHoursIndex1,
+                """
+                        invoke-virtual {p1}, Lde/simon/openinghours/models/Place;->getOpeningHours()Lde/simon/openinghours/models/OpeningHours;
+                        move-result-object v0
+                        if-eqz v0, :continue_0
+                        invoke-virtual {v0}, Lde/simon/openinghours/models/OpeningHours;->getWeekdayText()Lio/realm/RealmList;
+                        move-result-object v0
+                        if-eqz v0, :continue_0
+                        check-cast v0, Ljava/util/List;
+                        invoke-direct {p0, v0}, Lde/simon/openinghours/views/custom/PlaceCard;->setWeekDayText(Ljava/util/List;)V
+
+                """,
+                continueLabel1,
+            )
+        }
+    }
+
+    private fun getIndicesOfInvoke(
+        instructions: List<IndexedValue<BuilderInstruction>>,
+        className: String,
+        methodName: String,
+    ): List<Int> = instructions.mapNotNull { (index, instruction) ->
+        val invokeInstruction = instruction as? ReferenceInstruction ?: return@mapNotNull null
+        val methodRef = invokeInstruction.reference as? MethodReference ?: return@mapNotNull null
+
+        if (methodRef.definingClass != className || methodRef.name != methodName) {
+            return@mapNotNull null
+        }
+
+        index
+    }
+
+}

--- a/src/main/kotlin/app/revanced/patches/openinghours/crash/fingerprints/SetPlaceFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/openinghours/crash/fingerprints/SetPlaceFingerprint.kt
@@ -1,0 +1,12 @@
+package app.revanced.patches.openinghours.crash.fingerprints
+
+import app.revanced.patcher.fingerprint.MethodFingerprint
+
+object SetPlaceFingerprint : MethodFingerprint(
+    "V",
+    parameters = listOf("Lde/simon/openinghours/models/Place;"),
+    customFingerprint = { methodDef, _ ->
+        methodDef.definingClass == "Lde/simon/openinghours/views/custom/PlaceCard;"
+                && methodDef.name == "setPlace"
+    }
+)


### PR DESCRIPTION
The app would crash with
```
FATAL EXCEPTION: main
Process: de.simon.openinghours, PID: 24551
java.lang.NullPointerException
       at de.simon.openinghours.views.custom.PlaceCard.setPlace(PlaceCard.kt:135)
       at de.simon.openinghours.views.viewHolder.MyPlaceViewHolder.bind(MyPlaceViewHolder.kt:24)
       at de.simon.openinghours.views.adapter.MyPlacesAdapter.onBindViewHolder(MyPlacesAdapter.kt:36)
       at de.simon.openinghours.views.adapter.MyPlacesAdapter.onBindViewHolder(MyPlacesAdapter.kt:11)
       at androidx.recyclerview.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:7065)
       at androidx.recyclerview.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:7107)
```
without this patch. The cause was that `openingHours` is `null` and there have been no null checks. On initial app usage it wasn't null but after several months of usage perhaps some background sync updated the opening hours and somehow set it to `null`.