### PR TITLE
fix(TikTok - Show seekbar): Constrain patch to app target `32.5.3`

### DIFF
--- a/src/main/kotlin/app/revanced/patches/tiktok/interaction/seekbar/ShowSeekbarPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/tiktok/interaction/seekbar/ShowSeekbarPatch.kt
@@ -13,8 +13,8 @@ import app.revanced.patches.tiktok.interaction.seekbar.fingerprints.ShouldShowSe
     name = "Show seekbar",
     description = "Shows progress bar for all video.",
     compatiblePackages = [
-        CompatiblePackage("com.ss.android.ugc.trill"),
-        CompatiblePackage("com.zhiliaoapp.musically")
+        CompatiblePackage("com.ss.android.ugc.trill", ["32.5.3"]),
+        CompatiblePackage("com.zhiliaoapp.musically", ["32.5.3"])
     ]
 )
 @Suppress("unused")


### PR DESCRIPTION
Constrain `Show seekbar` patch to 32.5.3 to fix https://github.com/ReVanced/revanced-patches-template/issues/131, read https://github.com/ReVanced/revanced-patches-template/issues/131