### PR TITLE
ci: Attest release artifacts

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
-          java-version: "17"
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Cache Gradle
         uses: burrunan/gradle-cache-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,24 +13,23 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Make sure the release step uses its own credentials:
-          # https://github.com/cycjimmy/semantic-release-action#private-packages
-          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
-          java-version: "17"
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Cache Gradle
-        uses: burrunan/gradle-cache-action@v2
+        uses: burrunan/gradle-cache-action@v3
 
       - name: Build
         env:
@@ -40,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: 'lts/*'
           cache: 'npm'
 
       - name: Install dependencies
@@ -54,6 +53,14 @@ jobs:
           fingerprint: ${{ vars.GPG_FINGERPRINT }}
 
       - name: Release
+        uses: cycjimmy/semantic-release-action@v4
+        id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm exec semantic-release
+
+      - name: Attest
+        if: steps.release.outputs.new_release_published == 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: 'Patches ${{ steps.release.outputs.new_release_git_tag }}'
+          subject-path: patches/build/libs/patches-*.rvp

--- a/.releaserc
+++ b/.releaserc
@@ -21,9 +21,8 @@
       "@semantic-release/git",
       {
         "assets": [
-          "README.md",
           "CHANGELOG.md",
-          "gradle.properties",
+          "gradle.properties"
         ],
         "message": "chore: Release v${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
@@ -36,14 +35,14 @@
             "path": "patches/build/libs/patches-!(*sources*|*javadoc*).rvp?(.asc)"
           }
         ],
-        successComment: false
+        "successComment": false
       }
     ],
     [
       "@saithodev/semantic-release-backmerge",
       {
-        backmergeBranches: [{"from": "main", "to": "dev"}],
-        clearWorkspace: true
+        "backmergeBranches": [{"from": "main", "to": "dev"}],
+        "clearWorkspace": true
       }
     ]
   ]

--- a/.releaserc
+++ b/.releaserc
@@ -21,6 +21,7 @@
       "@semantic-release/git",
       {
         "assets": [
+          "README.md",
           "CHANGELOG.md",
           "gradle.properties"
         ],


### PR DESCRIPTION
Recommend attestation CI to any future patches derivative, and also update some of the actions (changes which reflected in PR for revanced-patches)

This PR provide SLSA v1.0 Level 2 for all future derivative, providing alternative to GPG signing.

If anyone wishes to get SLSA v1.0 L3 -- *which is slightly more complicated* -- they're free to do so by making a reusable workflow described @
* https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3
* https://docs.github.com/en/actions/sharing-automations/reusing-workflows

This PR will be mirrored with:
* ReVanced/revanced-patches#4816