### PR TITLE
docs: Make license section use American spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can find the contribution guidelines [here](CONTRIBUTING.md).
 To build ReVanced Patches template,
 you can follow the [ReVanced documentation](https://github.com/ReVanced/revanced-documentation).
 
-## 📜 Licence
+## 📜 License
 
 ReVanced Patches template is licensed under the GPLv3 licence.
 Please see the [license file](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ you can follow the [ReVanced documentation](https://github.com/ReVanced/revanced
 
 ## 📜 License
 
-ReVanced Patches template is licensed under the GPLv3 licence.
+ReVanced Patches template is licensed under the GPLv3 license.
 Please see the [license file](LICENSE) for more information.
 [tl;dr](https://www.tldrlegal.com/license/gnu-general-public-license-v3-gpl-3) you may copy, distribute
 and modify ReVanced Patches template as long as you track changes/dates in source files.


### PR DESCRIPTION
This is on my todolist for a very long time, I'll propagate this PR to other revanced repositories after the PR is merged within N+2 days unless requested change.

The license section uses British spelling of the word license ("licence"), which isn't intentional because ReVanced uses American spelling officially. 

Propagator!